### PR TITLE
Add dependency repos for release chart

### DIFF
--- a/.github/workflows/release-charts.yml
+++ b/.github/workflows/release-charts.yml
@@ -26,6 +26,10 @@ jobs:
         with:
           version: v3.5.0
 
+      - name: Add dependency chart repos
+        run: |
+          helm repo add kube-prometheus-stack https://prometheus-community.github.io/helm-charts
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.2.1
         env:


### PR DESCRIPTION
Signed-off-by: Sahil Raja <sahil.raja@mayadata.io>

- Add dependency repos for release chart
  ```
  - name: Add dependency chart repos
    run: |
      helm repo add kube-prometheus-stack https://prometheus-community.github.io/helm-charts
  ```