### PR TITLE
Relabel configs added for cstor pools and volumes

### DIFF
--- a/deploy/charts/openebs-monitoring/Chart.yaml
+++ b/deploy/charts/openebs-monitoring/Chart.yaml
@@ -34,7 +34,7 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: 0.1.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deploy/charts/openebs-monitoring/README.md
+++ b/deploy/charts/openebs-monitoring/README.md
@@ -104,19 +104,19 @@ helm install openebs-monitoring openebs-monitoring/monitoring --namespace openeb
 | `serviceMonitors.cstor.enabled`                            | Enables monitoring of cStor volumes          | `true`                             |
 | `serviceMonitors.cstor.endpoints.ports`                    | Name of the service port cstor volume endpoint refers to  | `"exporter"`          |
 | `serviceMonitors.cstor.endpoints.path`                     | HTTP path to scrape for metrics from cstor volume         | `"/metrics"`          |
-| `serviceMonitors.cstor.endpoints.relabelings`              | Allows dynamic rewriting of the label set to apply to samples before ingestion    | `[...]`                |
+| `serviceMonitors.cstor.endpoints.relabelings`              | RelabelConfigs to apply to cstor volumes before scraping  | `[...]`               |
 | `serviceMonitors.cstor.selector`                           | Selector to select endpoints objects         | `{matchLabels: {openebs.io/cas-type: cstor}}`               |
 | `serviceMonitors.cstor.namespaceSelector`                  | Selector to select which namespaces the endpoints objects are discovered from                        | `[any: true]`                         |
 | `serviceMonitors.jiva.enabled`                             | Enables monitoring of jiva volumes           | `true`                             |
 | `serviceMonitors.jiva.endpoints.ports`                     | Name of the service port jiva volume endpoint refers to  | `"exporter"`           |
 | `serviceMonitors.jiva.endpoints.path`                      | HTTP path to scrape for metrics from jiva volume         | `"/metrics"`           |
-| `serviceMonitors.jiva.endpoints.relabelings`               | Allows dynamic rewriting of the label set to apply to samples before ingestion    | `[]`                   |
+| `serviceMonitors.jiva.endpoints.relabelings`               | RelabelConfigs to apply to jiva volumes before scraping  | `[]`                   |
 | `serviceMonitors.jiva.selector`                            | Selector to select endpoints objects         | `{matchLabels: {openebs.io/cas-type: jiva}}`                |
 | `serviceMonitors.jiva.namespaceSelector`                   | Selector to select which namespaces the endpoints objects are discovered from                        | `[any: true]`                         |
-| `podMonitors.cstor.enabled`                                | Enables monitoring of cStor pools             | `true`                            |
+| `podMonitors.cstor.enabled`                                | Enables monitoring of cStor pools            | `true`                             |
 | `podMonitors.cstor.podMetricsEndpoints.targetPort`         | Name or number of the cstor pool endpoint's target port    | `9500`               |
 | `podMonitors.cstor.podMetricsEndpoints.path`               | HTTP path to scrape for metrics from cstor pool pod        | `"/metrics"`         |
-| `podMonitors.cstor.podMetricsEndpoints.relabelings`        | Allows dynamic rewriting of the label set to apply to samples before ingestion    | `[...]`                |
+| `podMonitors.cstor.podMetricsEndpoints.relabelings`        | RelabelConfigs to apply to cstor pools before scraping     | `[...]`              |
 | `podMonitors.cstor.selector`                               | Selector to select endpoints objects                       | `{matchLabels: {app: cstor-pool}}`          |
 | `podMonitors.cstor.namespaceSelector`                      | Selector to select which namespaces the endpoints objects are discovered from                        | `[any: true]`                         |
 

--- a/deploy/charts/openebs-monitoring/README.md
+++ b/deploy/charts/openebs-monitoring/README.md
@@ -87,31 +87,37 @@ helm install openebs-monitoring openebs-monitoring/monitoring --namespace openeb
 	--set kube-prometheus-stack.kubeProxy.enabled=false
 ```
 
-| Parameter                                           | Description                                   | Default                                   |
-| --------------------------------------------------- | --------------------------------------------- | ----------------------------------------- |
-| `kube-prometheus-stack.prometheus.service.type`     | Service type for Prometheus                   | `"NodePort"`                              |
-| `kube-prometheus-stack.prometheus.service.nodePort` | NodePort value for Prometheus service         | `32514`                                   |
-| `kube-prometheus-stack.grafana.service.type`        | Service type for Grafana                      | `"NodePort"`                              |
-| `kube-prometheus-stack.grafana.service.nodePort`    | NodePort value for Grafana service            | `32515`                                   |
+| Parameter                                                  | Description                                  | Default                            |
+| ---------------------------------------------------------- | -------------------------------------------- | ---------------------------------- |
+| `kube-prometheus-stack.prometheus.service.type`            | Service type for Prometheus                  | `"NodePort"`                       |
+| `kube-prometheus-stack.prometheus.service.nodePort`        | NodePort value for Prometheus service        | `32514`                            |
+| `kube-prometheus-stack.grafana.service.type`               | Service type for Grafana                     | `"NodePort"`                       |
+| `kube-prometheus-stack.grafana.service.nodePort`           | NodePort value for Grafana service           | `32515`                            |
 | `kube-prometheus-stack.prometheus.prometheusSpec.serviceMonitorSelectorNilUsesHelmValues` | Enables prometheus to select every service monitors               | `false`                         |
 | `kube-prometheus-stack.prometheus.prometheusSpec.podMonitorSelectorNilUsesHelmValues`     | Enables prometheus to select every pod monitors          | `false`                          |
-| `kube-prometheus-stack.grafana.enabled`                    | Enables monitoring of grafana itself         | `true`                           |
-| `kube-prometheus-stack.grafana.defaultDashboardsEnabled`   | Deploys default dashboards                   | `true`                           |
-| `kube-prometheus-stack.grafana.customDashboardsEnabled`    | Deploys custom OpenEBS dashboards            | `true`                           |
-| `kube-prometheus-stack.grafana.adminPassword`              | Administrator password for Grafana           | `"admin"`                        |
-| `kube-prometheus-stack.grafana.sidecar.dashboards.enabled` | Allows grafana sidecar container to provision dashboards  | `true`              |
-| `kube-prometheus-stack.grafana.sidecar.dashboards.label`   | Labels for configmaps to be collected by grafana sidecars | `"grafana_dashboard"`                      |
-| `serviceMonitors.cstor.enabled`                            | Enables monitoring of cStor volumes          | `true`                           |
-| `serviceMonitors.cstor.endpoints`                          | Scrapeable cstor volume endpoint serving Prometheus metrics | `[port: exporter, path: /metrics]`         |
-| `serviceMonitors.cstor.selector`                           | Selector to select endpoints objects         | `{matchLabels: {openebs.io/cas-type: cstor}}`                |
+| `kube-prometheus-stack.grafana.enabled`                    | Enables monitoring of grafana itself         | `true`                             |
+| `kube-prometheus-stack.grafana.defaultDashboardsEnabled`   | Deploys default dashboards                   | `true`                             |
+| `kube-prometheus-stack.grafana.customDashboardsEnabled`    | Deploys custom OpenEBS dashboards            | `true`                             |
+| `kube-prometheus-stack.grafana.adminPassword`              | Administrator password for Grafana           | `"admin"`                          |
+| `kube-prometheus-stack.grafana.sidecar.dashboards.enabled` | Allows grafana sidecar container to provision dashboards  | `true`                |
+| `kube-prometheus-stack.grafana.sidecar.dashboards.label`   | Labels for configmaps to be collected by grafana sidecars | `"grafana_dashboard"` |
+| `serviceMonitors.cstor.enabled`                            | Enables monitoring of cStor volumes          | `true`                             |
+| `serviceMonitors.cstor.endpoints.ports`                    | Name of the service port cstor volume endpoint refers to  | `"exporter"`          |
+| `serviceMonitors.cstor.endpoints.path`                     | HTTP path to scrape for metrics from cstor volume         | `"/metrics"`          |
+| `serviceMonitors.cstor.endpoints.relabelings`              | Allows dynamic rewriting of the label set to apply to samples before ingestion    | `[...]`                |
+| `serviceMonitors.cstor.selector`                           | Selector to select endpoints objects         | `{matchLabels: {openebs.io/cas-type: cstor}}`               |
 | `serviceMonitors.cstor.namespaceSelector`                  | Selector to select which namespaces the endpoints objects are discovered from                        | `[any: true]`                         |
-| `serviceMonitors.jiva.enabled`                             | Enables monitoring of jiva volumes           | `true`                           |
-| `serviceMonitors.jiva.endpoints`                           | Scrapeable jiva volume endpoint serving Prometheus metrics | `[port: exporter, path: /metrics]`         |
-| `serviceMonitors.jiva.selector`                            | Selector to select endpoints objects                       | `{matchLabels: {openebs.io/cas-type: jiva}}`                |
+| `serviceMonitors.jiva.enabled`                             | Enables monitoring of jiva volumes           | `true`                             |
+| `serviceMonitors.jiva.endpoints.ports`                     | Name of the service port jiva volume endpoint refers to  | `"exporter"`           |
+| `serviceMonitors.jiva.endpoints.path`                      | HTTP path to scrape for metrics from jiva volume         | `"/metrics"`           |
+| `serviceMonitors.jiva.endpoints.relabelings`               | Allows dynamic rewriting of the label set to apply to samples before ingestion    | `[]`                   |
+| `serviceMonitors.jiva.selector`                            | Selector to select endpoints objects         | `{matchLabels: {openebs.io/cas-type: jiva}}`                |
 | `serviceMonitors.jiva.namespaceSelector`                   | Selector to select which namespaces the endpoints objects are discovered from                        | `[any: true]`                         |
-| `podMonitors.cstor.enabled`                                | Enables monitoring of cStor pools             | `true`                          |
-| `podMonitors.cstor.podMetricsEndpoints`                    | Scrapeable cstor pod endpoint serving Prometheus metrics   | `[targetPort: 9500, path: /metrics]`         |
-| `podMonitors.cstor.selector`                               | Selector to select endpoints objects                       | `{matchLabels: {app: cstor-pool}}`                |
+| `podMonitors.cstor.enabled`                                | Enables monitoring of cStor pools             | `true`                            |
+| `podMonitors.cstor.podMetricsEndpoints.targetPort`         | Name or number of the cstor pool endpoint's target port    | `9500`               |
+| `podMonitors.cstor.podMetricsEndpoints.path`               | HTTP path to scrape for metrics from cstor pool pod        | `"/metrics"`         |
+| `podMonitors.cstor.podMetricsEndpoints.relabelings`        | Allows dynamic rewriting of the label set to apply to samples before ingestion    | `[...]`                |
+| `podMonitors.cstor.selector`                               | Selector to select endpoints objects                       | `{matchLabels: {app: cstor-pool}}`          |
 | `podMonitors.cstor.namespaceSelector`                      | Selector to select which namespaces the endpoints objects are discovered from                        | `[any: true]`                         |
 
 A YAML file that specifies the values for the parameters can be provided while installing the chart. For example,

--- a/deploy/charts/openebs-monitoring/README.md
+++ b/deploy/charts/openebs-monitoring/README.md
@@ -110,7 +110,7 @@ helm install openebs-monitoring openebs-monitoring/monitoring --namespace openeb
 | `serviceMonitors.jiva.enabled`                             | Enables monitoring of jiva volumes           | `true`                             |
 | `serviceMonitors.jiva.endpoints.ports`                     | Name of the service port jiva volume endpoint refers to  | `"exporter"`           |
 | `serviceMonitors.jiva.endpoints.path`                      | HTTP path to scrape for metrics from jiva volume         | `"/metrics"`           |
-| `serviceMonitors.jiva.endpoints.relabelings`               | RelabelConfigs to apply to jiva volumes before scraping  | `[]`                   |
+| `serviceMonitors.jiva.endpoints.relabelings`               | RelabelConfigs to apply to jiva volumes before scraping  | `[...]`                |
 | `serviceMonitors.jiva.selector`                            | Selector to select endpoints objects         | `{matchLabels: {openebs.io/cas-type: jiva}}`                |
 | `serviceMonitors.jiva.namespaceSelector`                   | Selector to select which namespaces the endpoints objects are discovered from                        | `[any: true]`                         |
 | `podMonitors.cstor.enabled`                                | Enables monitoring of cStor pools            | `true`                             |

--- a/deploy/charts/openebs-monitoring/templates/podmonitors.yaml
+++ b/deploy/charts/openebs-monitoring/templates/podmonitors.yaml
@@ -15,7 +15,12 @@ spec:
   namespaceSelector:
 {{ toYaml $fields.namespaceSelector | indent 4 }}
   podMetricsEndpoints:
-{{ toYaml $fields.podMetricsEndpoints | indent 2 }}
+    - targetPort: {{ $fields.podMetricsEndpoints.targetPort }}
+      path: {{ $fields.podMetricsEndpoints.path }}
+{{- if $fields.podMetricsEndpoints.relabelings }}
+      relabelings:
+{{ toYaml $fields.podMetricsEndpoints.relabelings | indent 8 }}
+{{- end }}
 ---
 {{- end }}
 {{- end }}

--- a/deploy/charts/openebs-monitoring/templates/servicemonitors.yaml
+++ b/deploy/charts/openebs-monitoring/templates/servicemonitors.yaml
@@ -15,7 +15,12 @@ spec:
   namespaceSelector:
 {{ toYaml $fields.namespaceSelector | indent 4 }}
   endpoints:
-{{ toYaml $fields.endpoints | indent 2 }}
+    - port: {{ $fields.endpoints.port }}
+      path: {{ $fields.endpoints.path }}
+{{- if $fields.endpoints.relabelings }}
+      relabelings:
+{{ toYaml $fields.endpoints.relabelings | indent 8 }}
+{{- end }}
 ---
 {{- end }}
 {{- end }}

--- a/deploy/charts/openebs-monitoring/values.yaml
+++ b/deploy/charts/openebs-monitoring/values.yaml
@@ -97,7 +97,7 @@ serviceMonitors:
           targetLabel: openebs_pv
         - sourceLabels: [__meta_kubernetes_pod_label_openebs_io_persistent_volume_claim]
           action: replace
-          targetLabel: openebs_pvc 
+          targetLabel: openebs_pvc
 
     ## Label selector for services to which this ServiceMonitor applies
     # selector: {}

--- a/deploy/charts/openebs-monitoring/values.yaml
+++ b/deploy/charts/openebs-monitoring/values.yaml
@@ -58,23 +58,46 @@ serviceMonitors:
     enabled: true
 
     ## Endpoints of the selected service to be monitored
-    # endpoints: []
-
-    ## Name of the endpoint's service port
-    ## Mutually exclusive with targetPort
-    #   - port: ""
-
-    ## HTTP path to scrape for metrics
-    #     path: /metrics
-
-    ## Example
-
-    # endpoints:
-    #   - port: exporter
-    #     path: /metrics
     endpoints:
-      - port: exporter
-        path: /mertics
+      ## Name of the endpoint's service port
+      ## Mutually exclusive with targetPort
+      #  port: ""
+      port: exporter
+
+      ## HTTP path to scrape for metrics
+      #  path: /metrics
+      path: /metrics
+
+      ## relabel configs to apply to samples before ingestion.
+      ##
+      #  relabelings: []
+      #    - sourceLabels: [__meta_kubernetes_service_name]
+      #      separator: ;
+      #      regex: (.*)
+      #      targetLabel: service
+      #      replacement: $1
+      #      action: replace
+      relabelings:
+        # RelabelConfigs to apply to samples before scraping.
+        # More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+        # To know more about RelabelConfig schema visit: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
+        - sourceLabels: [__meta_kubernetes_pod_label_monitoring]
+          regex: volume_exporter_prometheus
+          action: keep
+        # Below entry ending with vsm is deprecated and is maintained for
+        # backward compatibility purpose.
+        - sourceLabels: [__meta_kubernetes_pod_label_vsm]
+          action: replace
+          targetLabel: openebs_pv
+        # Below entry is the correct entry. Though the above and below entries
+        # are having same target_label as openebs_pv, only one of them will be
+        # valid for any release.
+        - sourceLabels: [__meta_kubernetes_pod_label_openebs_io_persistent_volume]
+          action: replace
+          targetLabel: openebs_pv
+        - sourceLabels: [__meta_kubernetes_pod_label_openebs_io_persistent_volume_claim]
+          action: replace
+          targetLabel: openebs_pvc 
 
     ## Label selector for services to which this ServiceMonitor applies
     # selector: {}
@@ -117,23 +140,26 @@ serviceMonitors:
     enabled: true
 
     ## Endpoints of the selected service to be monitored
-    # endpoints: []
-    ## Name of the endpoint's service port
-    ## Mutually exclusive with targetPort
-    #   - port: ""
-
-    ## HTTP path to scrape for metrics
-    #     path: /metrics
-
-    ## Example
-
-    # endpoints:
-    #   - port: exporter
-    #     path: /metrics
-
     endpoints:
-      - port: exporter
-        path: /metrics
+      ## Name of the endpoint's service port
+      ## Mutually exclusive with targetPort
+      #  port: ""
+      port: exporter
+
+      ## HTTP path to scrape for metrics
+      #  path: /metrics
+      path: /metrics
+
+      ## relabel configs to apply to samples before ingestion.
+      ##
+      #  relabelings: []
+      #    - sourceLabels: [__meta_kubernetes_service_name]
+      #      separator: ;
+      #      regex: (.*)
+      #      targetLabel: service
+      #      replacement: $1
+      #      action: replace
+      relabelings: []
 
     ## Label selector for services to which this ServiceMonitor applies
     # selector: {}
@@ -178,23 +204,49 @@ podMonitors:
 
     ## Endpoints of the selected pods to be monitored
     ## https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#podmetricsendpoint
-    # podMetricsEndpoints: []
-    ## Name or number of the endpoint's target port
-    ## Mutually exclusive with port
-    #   - targetPort: ""
-
-    ## HTTP path to scrape for metrics
-    #     path: /metrics
-
-    ## Example
-
-    # podMetricsEndpoints:
-    #   - targetPort: 9500
-    #     path: /metrics
-
     podMetricsEndpoints:
-      - targetPort: 9500
-        path: /metrics
+      ## Name or number of the endpoint's target port
+      ## Mutually exclusive with port
+      #  targetPort: ""
+      targetPort: 9500
+
+      ## HTTP path to scrape for metrics
+      #     path: /metrics
+      path: /metrics
+
+      ## relabel configs to apply to samples before ingestion.
+      ##
+      #     relabelings: []
+      #     - sourceLabels: [__meta_kubernetes_pod_node_name]
+      #       separator: ;
+      #       regex: ^(.*)$
+      #       targetLabel: nodename
+      #       replacement: $1
+      #       action: replace
+      relabelings:
+        # RelabelConfigs to apply to samples before scraping.
+        # More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+        # To know more about RelabelConfig schema visit: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
+        - sourceLabels: [__meta_kubernetes_pod_annotation_openebs_io_monitoring]
+          regex: pool_exporter_prometheus
+          action: keep
+          # Adding comma-separated source_labels below in order to fetch the metrics for pool claim instances of SPC and CSPC kind
+        - sourceLabels: [__meta_kubernetes_pod_label_openebs_io_storage_pool_claim, __meta_kubernetes_pod_label_openebs_io_cstor_pool_cluster]
+          action: replace
+          # separator: Separator placed between concatenated source label values, default -> ;
+          separator: ''
+          targetLabel: storage_pool_claim
+          # Adding comma-separated source_labels below in order to fetch the metrics for pool instances of CSP and CSPI kind
+        - sourceLabels: [__meta_kubernetes_pod_label_openebs_io_cstor_pool, __meta_kubernetes_pod_label_openebs_io_cstor_pool_instance]
+          action: replace
+          # separator: Separator placed between concatenated source label values, default -> ;
+          separator: ''
+          targetLabel: cstor_pool
+        - sourceLabels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+          action: replace
+          regex: ([^:]+)(?::\d+)?;(\d+)
+          replacement: ${1}:${2}
+          targetLabel: __address__
 
     ## Label selector for pods to which this PodMonitor applies
     # selector: {}

--- a/deploy/charts/openebs-monitoring/values.yaml
+++ b/deploy/charts/openebs-monitoring/values.yaml
@@ -159,7 +159,27 @@ serviceMonitors:
       #      targetLabel: service
       #      replacement: $1
       #      action: replace
-      relabelings: []
+      relabelings:
+        # RelabelConfigs to apply to samples before scraping.
+        # More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+        # To know more about RelabelConfig schema visit: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
+        - sourceLabels: [__meta_kubernetes_pod_label_monitoring]
+          regex: volume_exporter_prometheus
+          action: keep
+        # Below entry ending with vsm is deprecated and is maintained for
+        # backward compatibility purpose.
+        - sourceLabels: [__meta_kubernetes_pod_label_vsm]
+          action: replace
+          targetLabel: openebs_pv
+        # Below entry is the correct entry. Though the above and below entries
+        # are having same target_label as openebs_pv, only one of them will be
+        # valid for any release.
+        - sourceLabels: [__meta_kubernetes_pod_label_openebs_io_persistent_volume]
+          action: replace
+          targetLabel: openebs_pv
+        - sourceLabels: [__meta_kubernetes_pod_label_openebs_io_persistent_volume_claim]
+          action: replace
+          targetLabel: openebs_pvc
 
     ## Label selector for services to which this ServiceMonitor applies
     # selector: {}


### PR DESCRIPTION
## What this PR does?
This PR adds supports for adding relabel Prometheus configs to apply to cStor pools and volumes & jiva volumes.

## What were the requirements for this PR?
To re-label Prometheus configuration.
When using probe configs, the metrics collected can set additional labels(subsequent relabeling involved) that can be used in queries and dashboards.

### How does this work?
By passing re-label configurations to the service monitors and pod monitors responsible for scraping cStor pools and volumes metrics. In service monitors relabelings belong to pod -> then how does it work?
[Answer] -> Since the service monitors apply configuration of `endpoints` role therefore for endpoints role, we have two points to note:
* If the endpoints belong to a service, all labels of the role: service discovery are attached.
* For all targets backed by a pod, all labels of the role: pod discovery are attached. 

And in the pod monitors since that applies to pod directly therefore the relabelings works fine there.

After relabeling, the metrics looks like this:
* Sample cStor Pool metric:
![Screenshot from 2021-05-18 14-25-39](https://user-images.githubusercontent.com/44068648/118671743-5a13c080-b815-11eb-973e-9daeecaa27ae.png)

* Sample cStor Volume metric:
![Screenshot from 2021-05-18 14-26-05](https://user-images.githubusercontent.com/44068648/118671908-7b74ac80-b815-11eb-8800-11b0bc3833b8.png)


Also changes in service monitors and pod monitors template is involved in this PR. 

Signed-off-by: Abhishek Agarwal <abhishek.agarwal@mayadata.io>