### PR TITLE
Added OpenEBS volume dashboard

### DIFF
--- a/deploy/charts/openebs-monitoring/Chart.yaml
+++ b/deploy/charts/openebs-monitoring/Chart.yaml
@@ -34,7 +34,7 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.8
+version: 0.1.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deploy/charts/openebs-monitoring/dashboards/cStor/cstor-pool.json
+++ b/deploy/charts/openebs-monitoring/dashboards/cStor/cstor-pool.json
@@ -170,12 +170,12 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "openebs_pool_status{pod=\"$cstor_pool\"}",
+          "expr": "openebs_pool_status{cstor_pool=\"$cstor_pool\"}",
           "format": "time_series",
           "instant": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{pod}}",
+          "legendFormat": "{{cstor_pool}}",
           "refId": "A"
         }
       ],
@@ -231,7 +231,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(openebs_pool_size{pod=\"$cstor_pool\"})/(1024*1024*1024)",
+          "expr": "sum(openebs_pool_size{cstor_pool=\"$cstor_pool\"})/(1024*1024*1024)",
           "interval": "",
           "legendFormat": "size",
           "refId": "A"
@@ -327,9 +327,9 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "(openebs_used_pool_capacity{pod=\"$cstor_pool\"})/(1024*1024*1024)",
+          "expr": "(openebs_used_pool_capacity{cstor_pool=\"$cstor_pool\"})/(1024*1024*1024)",
           "interval": "",
-          "legendFormat": "{{pod}}",
+          "legendFormat": "{{cstor_pool}}",
           "refId": "A"
         }
       ],
@@ -423,9 +423,9 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "(openebs_free_pool_capacity{pod=\"$cstor_pool\"})/(1024*1024*1024)",
+          "expr": "(openebs_free_pool_capacity{cstor_pool=\"$cstor_pool\"})/(1024*1024*1024)",
           "interval": "",
-          "legendFormat": "{{pod}}",
+          "legendFormat": "{{cstor_pool}}",
           "refId": "A"
         }
       ],
@@ -520,7 +520,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(openebs_total_read_count{pod=\"$cstor_pool\"})",
+          "expr": "sum(openebs_total_read_count{cstor_pool=\"$cstor_pool\"})",
           "interval": "",
           "legendFormat": "read iops",
           "refId": "A"
@@ -616,7 +616,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(openebs_total_write_count{pod=\"$cstor_pool\"})",
+          "expr": "sum(openebs_total_write_count{cstor_pool=\"$cstor_pool\"})",
           "interval": "",
           "legendFormat": "wrie_iops",
           "refId": "A"
@@ -706,7 +706,7 @@
         "multi": false,
         "name": "cstor_pool",
         "options": [],
-        "query": "label_values(openebs_pool_status, pod)",
+        "query": "label_values(openebs_pool_status, cstor_pool)",
         "refId": "StandardVariableQuery",
         "refresh": 2,
         "regex": "",
@@ -726,7 +726,7 @@
           "value": ";cstor-storage"
         },
         "datasource": null,
-        "definition": "label_values(openebs_pool_status{pod=\"$cstor_pool\"}, storage_pool_claim)",
+        "definition": "label_values(openebs_pool_status{cstor_pool=\"$cstor_pool\"}, storage_pool_claim)",
         "description": null,
         "error": null,
         "hide": 2,
@@ -735,7 +735,7 @@
         "multi": false,
         "name": "spc",
         "options": [],
-        "query": "label_values(openebs_pool_status{pod=\"$cstor_pool\"}, storage_pool_claim)",
+        "query": "label_values(openebs_pool_status{cstor_pool=\"$cstor_pool\"}, storage_pool_claim)",
         "refId": "StandardVariableQuery",
         "refresh": 0,
         "regex": "",

--- a/deploy/charts/openebs-monitoring/dashboards/cStor/cstor-pool.json
+++ b/deploy/charts/openebs-monitoring/dashboards/cStor/cstor-pool.json
@@ -1,736 +1,775 @@
 {
-	"annotations": {
-		"list": [
-		{
-			"builtIn": 1,
-			"datasource": "-- Grafana --",
-			"enable": true,
-			"hide": true,
-			"iconColor": "rgba(0, 211, 255, 1)",
-			"name": "Annotations & Alerts",
-			"type": "dashboard"
-		}
-		]
-	},
-	"editable": true,
-	"gnetId": null,
-	"graphTooltip": 0,
-	"id": 21,
-	"iteration": 1620550941122,
-	"links": [],
-	"panels": [
-		{
-		"datasource": "$datasource",
-		"description": "",
-		"fieldConfig": {
-			"defaults": {
-			"color": {
-				"mode": "palette-classic"
-			},
-			"custom": {
-				"axisLabel": "",
-				"axisPlacement": "auto",
-				"barAlignment": 0,
-				"drawStyle": "line",
-				"fillOpacity": 10,
-				"gradientMode": "opacity",
-				"hideFrom": {
-				"graph": false,
-				"legend": false,
-				"tooltip": false
-				},
-				"lineInterpolation": "linear",
-				"lineStyle": {
-				"fill": "solid"
-				},
-				"lineWidth": 1,
-				"pointSize": 5,
-				"scaleDistribution": {
-				"type": "linear"
-				},
-				"showPoints": "never",
-				"spanNulls": true
-			},
-			"mappings": [
-				{
-				"from": "",
-				"id": 1,
-				"text": "Offline",
-				"to": "",
-				"type": 1,
-				"value": "0"
-				},
-				{
-				"from": "",
-				"id": 2,
-				"text": "Online",
-				"to": "",
-				"type": 1,
-				"value": "1"
-				},
-				{
-				"from": "",
-				"id": 3,
-				"text": "Degraded",
-				"to": "",
-				"type": 1,
-				"value": "2"
-				},
-				{
-				"from": "",
-				"id": 4,
-				"text": "Faulted",
-				"to": "",
-				"type": 1,
-				"value": "3"
-				},
-				{
-				"from": "",
-				"id": 5,
-				"text": "Removed",
-				"to": "",
-				"type": 1,
-				"value": "4"
-				},
-				{
-				"from": "",
-				"id": 6,
-				"text": "Unavail",
-				"to": "",
-				"type": 1,
-				"value": "5"
-				},
-				{
-				"from": "",
-				"id": 7,
-				"text": "NoPoolsAvailable",
-				"to": "",
-				"type": 1,
-				"value": "6"
-				}
-			],
-			"max": 6,
-			"min": 0,
-			"thresholds": {
-				"mode": "absolute",
-				"steps": [
-				{
-					"color": "green",
-					"value": null
-				}
-				]
-			},
-			"unit": "none"
-			},
-			"overrides": []
-		},
-		"gridPos": {
-			"h": 8,
-			"w": 12,
-			"x": 0,
-			"y": 0
-		},
-		"id": 2,
-		"options": {
-			"graph": {},
-			"legend": {
-			"calcs": [],
-			"displayMode": "list",
-			"placement": "bottom"
-			},
-			"tooltipOptions": {
-			"mode": "single"
-			}
-		},
-		"pluginVersion": "7.5.3",
-		"repeat": null,
-		"repeatDirection": "h",
-		"targets": [
-			{
-			"exemplar": true,
-			"expr": "openebs_pool_status{pod=\"$cstor_pool\"}",
-			"format": "time_series",
-			"instant": false,
-			"interval": "",
-			"intervalFactor": 1,
-			"legendFormat": "{{pod}}",
-			"refId": "A"
-			}
-		],
-		"timeFrom": null,
-		"timeShift": null,
-		"title": "cStor Pool Status",
-		"type": "timeseries"
-		},
-		{
-		"aliasColors": {},
-		"bars": false,
-		"dashLength": 10,
-		"dashes": false,
-		"datasource": "$datasource",
-		"fieldConfig": {
-			"defaults": {},
-			"overrides": []
-		},
-		"fill": 1,
-		"fillGradient": 0,
-		"gridPos": {
-			"h": 8,
-			"w": 12,
-			"x": 12,
-			"y": 0
-		},
-		"hiddenSeries": false,
-		"id": 4,
-		"legend": {
-			"avg": false,
-			"current": false,
-			"max": false,
-			"min": false,
-			"show": true,
-			"total": false,
-			"values": false
-		},
-		"lines": true,
-		"linewidth": 1,
-		"nullPointMode": "null",
-		"options": {
-			"alertThreshold": true
-		},
-		"percentage": false,
-		"pluginVersion": "7.5.5",
-		"pointradius": 2,
-		"points": false,
-		"renderer": "flot",
-		"seriesOverrides": [],
-		"spaceLength": 10,
-		"stack": false,
-		"steppedLine": false,
-		"targets": [
-			{
-			"exemplar": true,
-			"expr": "sum(openebs_pool_size{pod=\"$cstor_pool\"})/(1024*1024*1024)",
-			"interval": "",
-			"legendFormat": "size",
-			"refId": "A"
-			}
-		],
-		"thresholds": [],
-		"timeFrom": null,
-		"timeRegions": [],
-		"timeShift": null,
-		"title": "cStor Pool Size",
-		"tooltip": {
-			"shared": true,
-			"sort": 0,
-			"value_type": "individual"
-		},
-		"type": "graph",
-		"xaxis": {
-			"buckets": null,
-			"mode": "time",
-			"name": null,
-			"show": true,
-			"values": []
-		},
-		"yaxes": [
-			{
-			"$$hashKey": "object:489",
-			"format": "decgbytes",
-			"label": null,
-			"logBase": 1,
-			"max": null,
-			"min": null,
-			"show": true
-			},
-			{
-			"$$hashKey": "object:490",
-			"format": "short",
-			"label": null,
-			"logBase": 1,
-			"max": null,
-			"min": null,
-			"show": false
-			}
-		],
-		"yaxis": {
-			"align": false,
-			"alignLevel": null
-		}
-		},
-		{
-		"aliasColors": {},
-		"bars": false,
-		"dashLength": 10,
-		"dashes": false,
-		"datasource": "$datasource",
-		"fieldConfig": {
-			"defaults": {},
-			"overrides": []
-		},
-		"fill": 1,
-		"fillGradient": 0,
-		"gridPos": {
-			"h": 8,
-			"w": 12,
-			"x": 0,
-			"y": 8
-		},
-		"hiddenSeries": false,
-		"id": 6,
-		"legend": {
-			"avg": false,
-			"current": false,
-			"max": false,
-			"min": false,
-			"show": true,
-			"total": false,
-			"values": false
-		},
-		"lines": true,
-		"linewidth": 1,
-		"nullPointMode": "null",
-		"options": {
-			"alertThreshold": true
-		},
-		"percentage": false,
-		"pluginVersion": "7.5.5",
-		"pointradius": 2,
-		"points": false,
-		"renderer": "flot",
-		"seriesOverrides": [],
-		"spaceLength": 10,
-		"stack": false,
-		"steppedLine": false,
-		"targets": [
-			{
-			"exemplar": true,
-			"expr": "(openebs_used_pool_capacity{pod=\"$cstor_pool\"})/(1024*1024*1024)",
-			"interval": "",
-			"legendFormat": "{{pod}}",
-			"refId": "A"
-			}
-		],
-		"thresholds": [],
-		"timeFrom": null,
-		"timeRegions": [],
-		"timeShift": null,
-		"title": "Used Pool Capacity",
-		"tooltip": {
-			"shared": true,
-			"sort": 0,
-			"value_type": "individual"
-		},
-		"type": "graph",
-		"xaxis": {
-			"buckets": null,
-			"mode": "time",
-			"name": null,
-			"show": true,
-			"values": []
-		},
-		"yaxes": [
-			{
-			"$$hashKey": "object:575",
-			"format": "decgbytes",
-			"label": null,
-			"logBase": 1,
-			"max": null,
-			"min": null,
-			"show": true
-			},
-			{
-			"$$hashKey": "object:576",
-			"format": "short",
-			"label": null,
-			"logBase": 1,
-			"max": null,
-			"min": null,
-			"show": false
-			}
-		],
-		"yaxis": {
-			"align": false,
-			"alignLevel": null
-		}
-		},
-		{
-		"aliasColors": {},
-		"bars": false,
-		"dashLength": 10,
-		"dashes": false,
-		"datasource": "$datasource",
-		"fieldConfig": {
-			"defaults": {},
-			"overrides": []
-		},
-		"fill": 1,
-		"fillGradient": 0,
-		"gridPos": {
-			"h": 8,
-			"w": 12,
-			"x": 12,
-			"y": 8
-		},
-		"hiddenSeries": false,
-		"id": 8,
-		"legend": {
-			"avg": false,
-			"current": false,
-			"max": false,
-			"min": false,
-			"show": true,
-			"total": false,
-			"values": false
-		},
-		"lines": true,
-		"linewidth": 1,
-		"nullPointMode": "null",
-		"options": {
-			"alertThreshold": true
-		},
-		"percentage": false,
-		"pluginVersion": "7.5.5",
-		"pointradius": 2,
-		"points": false,
-		"renderer": "flot",
-		"seriesOverrides": [],
-		"spaceLength": 10,
-		"stack": false,
-		"steppedLine": false,
-		"targets": [
-			{
-			"exemplar": true,
-			"expr": "(openebs_free_pool_capacity{pod=\"$cstor_pool\"})/(1024*1024*1024)",
-			"interval": "",
-			"legendFormat": "{{pod}}",
-			"refId": "A"
-			}
-		],
-		"thresholds": [],
-		"timeFrom": null,
-		"timeRegions": [],
-		"timeShift": null,
-		"title": "Pool Free Capacity",
-		"tooltip": {
-			"shared": true,
-			"sort": 0,
-			"value_type": "individual"
-		},
-		"type": "graph",
-		"xaxis": {
-			"buckets": null,
-			"mode": "time",
-			"name": null,
-			"show": true,
-			"values": []
-		},
-		"yaxes": [
-			{
-			"$$hashKey": "object:661",
-			"decimals": 4,
-			"format": "decgbytes",
-			"label": null,
-			"logBase": 1,
-			"max": null,
-			"min": null,
-			"show": true
-			},
-			{
-			"$$hashKey": "object:662",
-			"format": "short",
-			"label": null,
-			"logBase": 1,
-			"max": null,
-			"min": null,
-			"show": false
-			}
-		],
-		"yaxis": {
-			"align": false,
-			"alignLevel": null
-		}
-		},
-		{
-		"aliasColors": {},
-		"bars": false,
-		"dashLength": 10,
-		"dashes": false,
-		"datasource": "$datasource",
-		"fieldConfig": {
-			"defaults": {},
-			"overrides": []
-		},
-		"fill": 1,
-		"fillGradient": 0,
-		"gridPos": {
-			"h": 8,
-			"w": 12,
-			"x": 0,
-			"y": 16
-		},
-		"hiddenSeries": false,
-		"id": 11,
-		"legend": {
-			"avg": false,
-			"current": false,
-			"max": false,
-			"min": false,
-			"show": true,
-			"total": false,
-			"values": false
-		},
-		"lines": true,
-		"linewidth": 1,
-		"nullPointMode": "null",
-		"options": {
-			"alertThreshold": true
-		},
-		"percentage": false,
-		"pluginVersion": "7.5.5",
-		"pointradius": 2,
-		"points": false,
-		"renderer": "flot",
-		"seriesOverrides": [],
-		"spaceLength": 10,
-		"stack": false,
-		"steppedLine": false,
-		"targets": [
-			{
-			"exemplar": true,
-			"expr": "sum(openebs_total_read_count{pod=\"$cstor_pool\"})",
-			"interval": "",
-			"legendFormat": "read iops",
-			"refId": "A"
-			}
-		],
-		"thresholds": [],
-		"timeFrom": null,
-		"timeRegions": [],
-		"timeShift": null,
-		"title": "Read IOPS",
-		"tooltip": {
-			"shared": true,
-			"sort": 0,
-			"value_type": "individual"
-		},
-		"type": "graph",
-		"xaxis": {
-			"buckets": null,
-			"mode": "time",
-			"name": null,
-			"show": true,
-			"values": []
-		},
-		"yaxes": [
-			{
-			"$$hashKey": "object:1223",
-			"format": "short",
-			"label": null,
-			"logBase": 1,
-			"max": null,
-			"min": null,
-			"show": true
-			},
-			{
-			"$$hashKey": "object:1224",
-			"format": "short",
-			"label": null,
-			"logBase": 1,
-			"max": null,
-			"min": null,
-			"show": false
-			}
-		],
-		"yaxis": {
-			"align": false,
-			"alignLevel": null
-		}
-		},
-		{
-		"aliasColors": {},
-		"bars": false,
-		"dashLength": 10,
-		"dashes": false,
-		"datasource": "$datasource",
-		"fieldConfig": {
-			"defaults": {},
-			"overrides": []
-		},
-		"fill": 1,
-		"fillGradient": 0,
-		"gridPos": {
-			"h": 8,
-			"w": 12,
-			"x": 12,
-			"y": 16
-		},
-		"hiddenSeries": false,
-		"id": 12,
-		"legend": {
-			"avg": false,
-			"current": false,
-			"max": false,
-			"min": false,
-			"show": true,
-			"total": false,
-			"values": false
-		},
-		"lines": true,
-		"linewidth": 1,
-		"nullPointMode": "null",
-		"options": {
-			"alertThreshold": true
-		},
-		"percentage": false,
-		"pluginVersion": "7.5.5",
-		"pointradius": 2,
-		"points": false,
-		"renderer": "flot",
-		"seriesOverrides": [],
-		"spaceLength": 10,
-		"stack": false,
-		"steppedLine": false,
-		"targets": [
-			{
-			"exemplar": true,
-			"expr": "sum(openebs_total_write_count{pod=\"$cstor_pool\"})",
-			"interval": "",
-			"legendFormat": "wrie_iops",
-			"refId": "A"
-			}
-		],
-		"thresholds": [],
-		"timeFrom": null,
-		"timeRegions": [],
-		"timeShift": null,
-		"title": "Write IOPS",
-		"tooltip": {
-			"shared": true,
-			"sort": 0,
-			"value_type": "individual"
-		},
-		"type": "graph",
-		"xaxis": {
-			"buckets": null,
-			"mode": "time",
-			"name": null,
-			"show": true,
-			"values": []
-		},
-		"yaxes": [
-			{
-			"$$hashKey": "object:1625",
-			"format": "short",
-			"label": null,
-			"logBase": 1,
-			"max": null,
-			"min": null,
-			"show": true
-			},
-			{
-			"$$hashKey": "object:1626",
-			"format": "short",
-			"label": null,
-			"logBase": 1,
-			"max": null,
-			"min": null,
-			"show": false
-			}
-		],
-		"yaxis": {
-			"align": false,
-			"alignLevel": null
-		}
-		}
-	],
-	"refresh": "1m",
-	"schemaVersion": 27,
-	"style": "dark",
-	"tags": [
-		"OpenEBS"
-	],
-	"templating": {
-		"list": [
-		{
-			"current": {
-			"selected": true,
-			"text": "Prometheus",
-			"value": "Prometheus"
-			},
-			"description": null,
-			"error": null,
-			"hide": 0,
-			"includeAll": false,
-			"label": null,
-			"multi": false,
-			"name": "datasource",
-			"options": [],
-			"query": "prometheus",
-			"queryValue": "",
-			"refresh": 1,
-			"regex": "",
-			"skipUrlSync": false,
-			"type": "datasource"
-		},
-		{
-			"allValue": null,
-			"current": {},
-			"datasource": "$datasource",
-			"definition": "",
-			"description": null,
-			"error": null,
-			"hide": 0,
-			"includeAll": false,
-			"label": null,
-			"multi": false,
-			"name": "cstor_pool",
-			"options": [],
-			"query": "label_values(openebs_pool_status, pod)",
-			"refId": "StandardVariableQuery",
-			"refresh": 2,
-			"regex": "",
-			"skipUrlSync": false,
-			"sort": 0,
-			"tagValuesQuery": "",
-			"tags": [],
-			"tagsQuery": "",
-			"type": "query",
-			"useTags": false
-		}
-		]
-	},
-	"time": {
-		"from": "now-6h",
-		"to": "now"
-	},
-	"timepicker": {
-		"refresh_intervals": [
-		"5s",
-		"10s",
-		"30s",
-		"1m",
-		"5m",
-		"15m",
-		"30m",
-		"1h",
-		"2h",
-		"1d"
-		],
-		"time_options": [
-		"5m",
-		"15m",
-		"1h",
-		"6h",
-		"12h",
-		"24h",
-		"2d",
-		"7d",
-		"30d"
-		]
-	},
-	"timezone": "",
-	"title": "OpenEBS / cStor / Pool dashboard",
-	"uid": "5a50cd9e-2013-4a58-8d06-669103eb9717",
-	"version": 1
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 21,
+  "iteration": 1620550941122,
+  "links": [],
+  "panels": [
+    {
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 44,
+      "links": [],
+      "options": {
+        "content": "<html>\n<head>\n\n<script>\nwindow.onload = load('$cstor_pool', '$spc');\n\nfunction getCell(name, value) {\n  return \"<div class=\\\"col-lg\\\"><center><p>\"+name+\"</p><p>\"+value+\"</p></center></div>\";\n}\n\nfunction load(poolNameStr, spcStr) {\nvar poolNameStr = poolNameStr.replace( /[{}]/g, '' );\nvar spcStr = spcStr.replace( /[{}]/g, '' );\n//var kindStr = kindStr.replace( /[{}]/g, '' );\n// var pools = poolsStr.replace( /[{}]/g, '' );\n// var rc = replicaCount.replace( /[{}]/g, '' );\n// if(!rc) {\n//   rc = \"none\";\n// }\n// var uptimes = uptime.replace( /[{}]/g, '' );\n// if(uptimes) {\n// var seconds = parseInt(uptimes, 10);\n\n// var days = Math.floor(seconds / (3600*24));\n// seconds  -= days*3600*24;\n// var hrs   = Math.floor(seconds / 3600);\n// seconds  -= hrs*3600;\n// var mnts = Math.floor(seconds / 60);\n// seconds  -= mnts*60;\n// uptimes = days+\" days, \"+hrs+\" Hrs, \"+mnts+\" Mins, \"+seconds+\" Secs\";\n// }\n// else {\n//   uptimes = \"No Data\";\n// }\n\n\n\nz=\"\";\nz+=getCell(\"Pool Name\", poolNameStr);\n//z+=getCell(\"Name\", volName);\nz+=getCell(\"CStorPoolCluster\", spcStr);\n//z+=getCell(\"No. of Replicas\", rc);\n//z+=getCell(\"\",\"\")\n\ndocument.getElementById(\"volume-info\").innerHTML = z;\n}\n</script>\n</head>\n\n<body>\n\n<div class=\"container\"><div id=\"volume-info\" class=\"row\"></div></div>\n\n\n</body>\n\n\n</html>",
+        "mode": "html"
+      },
+      "pluginVersion": "7.5.5",
+      "title": "Pool information",
+      "type": "text"
+    },
+    {
+      "datasource": "$datasource",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "mappings": [
+            {
+              "from": "",
+              "id": 1,
+              "text": "Offline",
+              "to": "",
+              "type": 1,
+              "value": "0"
+            },
+            {
+              "from": "",
+              "id": 2,
+              "text": "Online",
+              "to": "",
+              "type": 1,
+              "value": "1"
+            },
+            {
+              "from": "",
+              "id": 3,
+              "text": "Degraded",
+              "to": "",
+              "type": 1,
+              "value": "2"
+            },
+            {
+              "from": "",
+              "id": 4,
+              "text": "Faulted",
+              "to": "",
+              "type": 1,
+              "value": "3"
+            },
+            {
+              "from": "",
+              "id": 5,
+              "text": "Removed",
+              "to": "",
+              "type": 1,
+              "value": "4"
+            },
+            {
+              "from": "",
+              "id": 6,
+              "text": "Unavail",
+              "to": "",
+              "type": 1,
+              "value": "5"
+            },
+            {
+              "from": "",
+              "id": 7,
+              "text": "NoPoolsAvailable",
+              "to": "",
+              "type": 1,
+              "value": "6"
+            }
+          ],
+          "max": 6,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltipOptions": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "7.5.3",
+      "repeat": null,
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "openebs_pool_status{pod=\"$cstor_pool\"}",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "cStor Pool Status",
+      "type": "timeseries"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 4,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.5",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(openebs_pool_size{pod=\"$cstor_pool\"})/(1024*1024*1024)",
+          "interval": "",
+          "legendFormat": "size",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "cStor Pool Size",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:489",
+          "format": "decgbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:490",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "hiddenSeries": false,
+      "id": 6,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.5",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "(openebs_used_pool_capacity{pod=\"$cstor_pool\"})/(1024*1024*1024)",
+          "interval": "",
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Used Pool Capacity",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:575",
+          "format": "decgbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:576",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "hiddenSeries": false,
+      "id": 8,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.5",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "(openebs_free_pool_capacity{pod=\"$cstor_pool\"})/(1024*1024*1024)",
+          "interval": "",
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Pool Free Capacity",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:661",
+          "decimals": 4,
+          "format": "decgbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:662",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "hiddenSeries": false,
+      "id": 11,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.5",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(openebs_total_read_count{pod=\"$cstor_pool\"})",
+          "interval": "",
+          "legendFormat": "read iops",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Read IOPS",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:1223",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:1224",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "hiddenSeries": false,
+      "id": 12,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.5",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(openebs_total_write_count{pod=\"$cstor_pool\"})",
+          "interval": "",
+          "legendFormat": "wrie_iops",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Write IOPS",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:1625",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:1626",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 27,
+  "style": "dark",
+  "tags": ["OpenEBS"],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "$datasource",
+        "definition": "",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "cstor_pool",
+        "options": [],
+        "query": "label_values(openebs_pool_status, pod)",
+        "refId": "StandardVariableQuery",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": ";cstor-storage",
+          "value": ";cstor-storage"
+        },
+        "datasource": null,
+        "definition": "label_values(openebs_pool_status{pod=\"$cstor_pool\"}, storage_pool_claim)",
+        "description": null,
+        "error": null,
+        "hide": 2,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "spc",
+        "options": [],
+        "query": "label_values(openebs_pool_status{pod=\"$cstor_pool\"}, storage_pool_claim)",
+        "refId": "StandardVariableQuery",
+        "refresh": 0,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": ["5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"]
+  },
+  "timezone": "",
+  "title": "OpenEBS / cStor / Pool dashboard",
+  "uid": "5a50cd9e-2013-4a58-8d06-669103eb9717",
+  "version": 1
 }

--- a/deploy/charts/openebs-monitoring/dashboards/openebs-volumes.json
+++ b/deploy/charts/openebs-monitoring/dashboards/openebs-volumes.json
@@ -1,0 +1,1185 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 26,
+  "iteration": 1621529330789,
+  "links": [],
+  "panels": [
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 55,
+      "links": [],
+      "options": {
+        "content": "<html>\n<head>\n\n<script>\nwindow.onload = load('$openebs_pvc', '$vol', '$pool', '$replica_count', '$uptime');\n\nfunction getCell(name, value) {\n  return \"<div class=\\\"col-lg\\\"><center><p>\"+name+\"</p><p>\"+value+\"</p></center></div>\";\n}\n\nfunction load(volClaimStr, volNameStr,poolsStr, replicaCount, uptime) {\nvar volClaim = volClaimStr.replace( /[{}]/g, '' );\nvar volName = volNameStr.replace( /[{}]/g, '' );\nvar pools = poolsStr.replace( /[{}]/g, '' );\nvar rc = replicaCount.replace( /[{}]/g, '' );\nif(!rc) {\n  rc = \"none\";\n}\nvar uptimes = uptime.replace( /[{}]/g, '' );\nif(uptimes) {\nvar seconds = parseInt(uptimes, 10);\n\nvar days = Math.floor(seconds / (3600*24));\nseconds  -= days*3600*24;\nvar hrs   = Math.floor(seconds / 3600);\nseconds  -= hrs*3600;\nvar mnts = Math.floor(seconds / 60);\nseconds  -= mnts*60;\nuptimes = days+\" days, \"+hrs+\" Hrs, \"+mnts+\" Mins\";\n}\nelse {\n  uptimes = \"No Data\";\n}\n\n\n\nz=\"\";\nz+=getCell(\"PVC\", volClaim);\n//z+=getCell(\"Name\", volName);\nz+=getCell(\"Pool Name\", pools);\nz+=getCell(\"No. of Replicas\", rc);\nz+=getCell(\"Uptime\", uptimes);\n//z+=getCell(\"\",\"\")\n\ndocument.getElementById(\"volume-info\").innerHTML = z;\n}\n</script>\n</head>\n\n<body>\n\n<div class=\"container\"><div id=\"volume-info\" class=\"row\"></div></div>\n\n</body>\n\n</html>",
+        "mode": "html"
+      },
+      "pluginVersion": "7.5.5",
+      "title": "Volume information",
+      "type": "text"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "mappings": [
+            {
+              "from": "",
+              "id": 1,
+              "text": "Offline",
+              "to": "",
+              "type": 1,
+              "value": "1"
+            },
+            {
+              "from": "",
+              "id": 2,
+              "text": "Degraded",
+              "to": "",
+              "type": 1,
+              "value": "2"
+            },
+            {
+              "from": "",
+              "id": 3,
+              "text": "Healthy",
+              "to": "",
+              "type": 1,
+              "value": "3"
+            },
+            {
+              "from": "",
+              "id": 4,
+              "text": "Unknown",
+              "to": "",
+              "type": 1,
+              "value": "4"
+            }
+          ],
+          "max": 4,
+          "min": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 4
+      },
+      "id": 35,
+      "links": [],
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltipOptions": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "7.5.5",
+      "targets": [
+        {
+          "expr": "openebs_volume_status{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "volume status",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Volume status",
+      "type": "timeseries"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 3,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 4
+      },
+      "hiddenSeries": false,
+      "id": 39,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.5",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "openebs_total_replica_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "total",
+          "refId": "A"
+        },
+        {
+          "expr": "openebs_healthy_replica_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "healthy",
+          "refId": "B"
+        },
+        {
+          "expr": "openebs_degraded_replica_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "degraded",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Replica count",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:416",
+          "decimals": 0,
+          "format": "none",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:417",
+          "format": "short",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 3,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 4
+      },
+      "hiddenSeries": false,
+      "id": 53,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.5",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "openebs_parse_error_total{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "total parse error",
+          "refId": "A"
+        },
+        {
+          "expr": "openebs_connection_retry_total{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "total connection retry",
+          "refId": "B"
+        },
+        {
+          "expr": "openebs_connection_error_total{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "total connection error",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Errors",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:532",
+          "format": "short",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:533",
+          "format": "short",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 3,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 11
+      },
+      "hiddenSeries": false,
+      "id": 22,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.5",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "irate(openebs_reads{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "Reads",
+          "refId": "A"
+        },
+        {
+          "expr": "irate(openebs_writes{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Writes",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "IOPS",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:864",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:865",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 3,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 11
+      },
+      "hiddenSeries": false,
+      "id": 23,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.5",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "((irate(openebs_read_time{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m]))/(irate(openebs_reads{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])))/1000000",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Read latency",
+          "refId": "A"
+        },
+        {
+          "expr": "((irate(openebs_write_time{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m]))/(irate(openebs_writes{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])))/1000000",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Write  latency",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Latency",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:783",
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:784",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 3,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 11
+      },
+      "hiddenSeries": false,
+      "id": 57,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.5",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "openebs_size_of_volume{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Total size",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Total capacity",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:593",
+          "format": "decgbytes",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:594",
+          "format": "short",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 3,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 19
+      },
+      "hiddenSeries": false,
+      "id": 28,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.5",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "openebs_actual_used{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "used",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Storage usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:702",
+          "format": "decgbytes",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:703",
+          "format": "short",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 3,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 19
+      },
+      "hiddenSeries": false,
+      "id": 31,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.5",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "irate(openebs_read_block_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])/(2048)",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Read Throughput",
+          "refId": "A"
+        },
+        {
+          "expr": "irate(openebs_write_block_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])/(2048)",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Write Throughput",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Throughput",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:1026",
+          "format": "MBs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:1027",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 3,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 19
+      },
+      "hiddenSeries": false,
+      "id": 26,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.5",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "(irate(openebs_read_block_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])/(1024))*512/(irate(openebs_reads{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m]))",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "Read block size",
+          "refId": "A"
+        },
+        {
+          "expr": "(irate(openebs_write_block_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])/(1024))*512/(irate(openebs_writes{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m]))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Write block size",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Block size",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:945",
+          "format": "deckbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:946",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 27,
+  "style": "light",
+  "tags": ["OpenEBS"],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "Prometheus",
+        "definition": "",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Volume",
+        "multi": false,
+        "name": "openebs_Volume",
+        "options": [],
+        "query": "label_values(openebs_size_of_volume, openebs_pv)",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "Prometheus",
+        "definition": "",
+        "description": null,
+        "error": null,
+        "hide": 2,
+        "includeAll": false,
+        "label": "Openebs pvc",
+        "multi": false,
+        "name": "openebs_pvc",
+        "options": [],
+        "query": "label_values(openebs_size_of_volume{openebs_pv=~\"$openebs_Volume\"},openebs_pvc)",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "Prometheus",
+        "definition": "",
+        "description": null,
+        "error": null,
+        "hide": 2,
+        "includeAll": false,
+        "label": "pool",
+        "multi": false,
+        "name": "pool",
+        "options": [],
+        "query": "label_values(openebs_replica_status{vol=~\"$openebs_Volume\"},pool)",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "Prometheus",
+        "definition": "",
+        "description": null,
+        "error": null,
+        "hide": 2,
+        "includeAll": false,
+        "label": "replica_count",
+        "multi": false,
+        "name": "replica_count",
+        "options": [],
+        "query": "query_result(openebs_total_replica_count{openebs_pv=~\"$openebs_Volume\"})",
+        "refresh": 2,
+        "regex": "/.*}(.*) .*/",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "Prometheus",
+        "definition": "",
+        "description": null,
+        "error": null,
+        "hide": 2,
+        "includeAll": false,
+        "label": "uptime",
+        "multi": false,
+        "name": "uptime",
+        "options": [],
+        "query": "query_result(openebs_volume_uptime{openebs_pv=~\"$openebs_Volume\"})",
+        "refresh": 2,
+        "regex": "/.*}(.*) .*/",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "Prometheus",
+        "definition": "",
+        "description": null,
+        "error": null,
+        "hide": 2,
+        "includeAll": false,
+        "label": "vol",
+        "multi": false,
+        "name": "vol",
+        "options": [],
+        "query": "label_values(openebs_size_of_volume{openebs_pvc=~\"$openebs_pvc\"},openebs_pv)",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": ["5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"]
+  },
+  "timezone": "",
+  "title": "OpenEBS Volume dashboard",
+  "uid": "f46a2d03-c2af-4954-b2b3-307c4d77bcaf",
+  "version": 1
+}

--- a/deploy/charts/openebs-monitoring/dashboards/openebs-volumes.json
+++ b/deploy/charts/openebs-monitoring/dashboards/openebs-volumes.json
@@ -26,7 +26,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
+        "h": 3,
         "w": 24,
         "x": 0,
         "y": 0
@@ -1074,7 +1074,7 @@
         "multi": false,
         "name": "pool",
         "options": [],
-        "query": "label_values(openebs_replica_status{vol=~\"$openebs_Volume\"},pool)",
+        "query": "label_values(openebs_replica_status{vol=~\"$openebs_Volume\"},cstor_pool)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,

--- a/deploy/charts/openebs-monitoring/dashboards/openebs-volumes.json
+++ b/deploy/charts/openebs-monitoring/dashboards/openebs-volumes.json
@@ -445,7 +445,7 @@
         {
           "expr": "irate(openebs_writes{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])",
           "format": "time_series",
-          "intervalFactor": 1,
+          "intervalFactor": 2,
           "legendFormat": "Writes",
           "refId": "B"
         }

--- a/deploy/charts/openebs-monitoring/dashboards/openebs-volumes.json
+++ b/deploy/charts/openebs-monitoring/dashboards/openebs-volumes.json
@@ -20,7 +20,7 @@
   "links": [],
   "panels": [
     {
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {},
         "overrides": []
@@ -160,7 +160,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {},
         "overrides": []
@@ -277,7 +277,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {},
         "overrides": []
@@ -392,7 +392,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {},
         "overrides": []
@@ -498,7 +498,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {},
         "overrides": []
@@ -602,7 +602,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {},
         "overrides": []
@@ -703,7 +703,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {},
         "overrides": []
@@ -802,7 +802,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {},
         "overrides": []
@@ -906,7 +906,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {},
         "overrides": []
@@ -1014,9 +1014,30 @@
   "templating": {
     "list": [
       {
+        "current": {
+          "selected": true,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
         "allValue": null,
         "current": {},
-        "datasource": "Prometheus",
+        "datasource": "$datasource",
         "definition": "",
         "description": null,
         "error": null,
@@ -1040,7 +1061,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "Prometheus",
+        "datasource": "$datasource",
         "definition": "",
         "description": null,
         "error": null,
@@ -1064,7 +1085,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "Prometheus",
+        "datasource": "$datasource",
         "definition": "",
         "description": null,
         "error": null,
@@ -1088,7 +1109,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "Prometheus",
+        "datasource": "$datasource",
         "definition": "",
         "description": null,
         "error": null,
@@ -1112,7 +1133,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "Prometheus",
+        "datasource": "$datasource",
         "definition": "",
         "description": null,
         "error": null,
@@ -1136,7 +1157,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "Prometheus",
+        "datasource": "$datasource",
         "definition": "",
         "description": null,
         "error": null,
@@ -1179,7 +1200,7 @@
     "time_options": ["5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"]
   },
   "timezone": "",
-  "title": "OpenEBS Volume dashboard",
+  "title": "OpenEBS / Volume dashboard",
   "uid": "f46a2d03-c2af-4954-b2b3-307c4d77bcaf",
   "version": 1
 }

--- a/deploy/charts/openebs-monitoring/values.yaml
+++ b/deploy/charts/openebs-monitoring/values.yaml
@@ -92,8 +92,8 @@ kube-prometheus-stack:
   grafana:
     enabled: true
 
-    # In order to render HTML and Javascript in a text panel without being sanitized
-    # enable the `disable_sanitize_html` settings in Grafana ini file
+    ## In order to render HTML and Javascript in a text panel without being sanitized
+    ## enable the `disable_sanitize_html` settings in Grafana ini file
     grafana.ini:
       panels:
         disable_sanitize_html: true
@@ -145,20 +145,20 @@ serviceMonitors:
       #     replacement: $1
       #     action: replace
       relabelings:
-        # RelabelConfigs to apply to samples before scraping.
-        # More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
-        # To know more about RelabelConfig schema visit: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
+        ## RelabelConfigs to apply to samples before scraping.
+        ## More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+        ## To know more about RelabelConfig schema visit: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
         - sourceLabels: [__meta_kubernetes_pod_label_monitoring]
           regex: volume_exporter_prometheus
           action: keep
-        # Below entry ending with vsm is deprecated and is maintained for
-        # backward compatibility purpose.
+        ## Below entry ending with vsm is deprecated and is maintained for
+        ## backward compatibility purpose.
         - sourceLabels: [__meta_kubernetes_pod_label_vsm]
           action: replace
           targetLabel: openebs_pv
-        # Below entry is the correct entry. Though the above and below entries
-        # are having same target_label as openebs_pv, only one of them will be
-        # valid for any release.
+        ## Below entry is the correct entry. Though the above and below entries
+        ## are having same target_label as openebs_pv, only one of them will be
+        ## valid for any release.
         - sourceLabels:
             [__meta_kubernetes_pod_label_openebs_io_persistent_volume]
           action: replace
@@ -229,20 +229,20 @@ serviceMonitors:
       #      replacement: $1
       #      action: replace
       relabelings:
-        # RelabelConfigs to apply to samples before scraping.
-        # More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
-        # To know more about RelabelConfig schema visit: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
+        ## RelabelConfigs to apply to samples before scraping.
+        ## More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+        ## To know more about RelabelConfig schema visit: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
         - sourceLabels: [__meta_kubernetes_pod_label_monitoring]
           regex: volume_exporter_prometheus
           action: keep
-        # Below entry ending with vsm is deprecated and is maintained for
-        # backward compatibility purpose.
+        ## Below entry ending with vsm is deprecated and is maintained for
+        ## backward compatibility purpose.
         - sourceLabels: [__meta_kubernetes_pod_label_vsm]
           action: replace
           targetLabel: openebs_pv
-        # Below entry is the correct entry. Though the above and below entries
-        # are having same target_label as openebs_pv, only one of them will be
-        # valid for any release.
+        ## Below entry is the correct entry. Though the above and below entries
+        ## are having same target_label as openebs_pv, only one of them will be
+        ## valid for any release.
         - sourceLabels:
             [__meta_kubernetes_pod_label_openebs_io_persistent_volume]
           action: replace
@@ -315,30 +315,30 @@ podMonitors:
       #       replacement: $1
       #       action: replace
       relabelings:
-        # RelabelConfigs to apply to samples before scraping.
-        # More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
-        # To know more about RelabelConfig schema visit: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
+        ## RelabelConfigs to apply to samples before scraping.
+        ## More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+        ## To know more about RelabelConfig schema visit: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
         - sourceLabels: [__meta_kubernetes_pod_annotation_openebs_io_monitoring]
           regex: pool_exporter_prometheus
           action: keep
-          # Adding comma-separated source_labels below in order to fetch the metrics for pool claim instances of SPC and CSPC kind
+          ## Adding comma-separated source_labels below in order to fetch the metrics for pool claim instances of SPC and CSPC kind
         - sourceLabels:
             [
               __meta_kubernetes_pod_label_openebs_io_storage_pool_claim,
               __meta_kubernetes_pod_label_openebs_io_cstor_pool_cluster,
             ]
           action: replace
-          # separator: Separator placed between concatenated source label values, default -> ;
+          ## separator: Separator placed between concatenated source label values, default -> ;
           separator: ""
           targetLabel: storage_pool_claim
-          # Adding comma-separated source_labels below in order to fetch the metrics for pool instances of CSP and CSPI kind
+          ## Adding comma-separated source_labels below in order to fetch the metrics for pool instances of CSP and CSPI kind
         - sourceLabels:
             [
               __meta_kubernetes_pod_label_openebs_io_cstor_pool,
               __meta_kubernetes_pod_label_openebs_io_cstor_pool_instance,
             ]
           action: replace
-          # separator: Separator placed between concatenated source label values, default -> ;
+          ## separator: Separator placed between concatenated source label values, default -> ;
           separator: ""
           targetLabel: cstor_pool
         - sourceLabels:

--- a/deploy/charts/openebs-monitoring/values.yaml
+++ b/deploy/charts/openebs-monitoring/values.yaml
@@ -92,6 +92,12 @@ kube-prometheus-stack:
   grafana:
     enabled: true
 
+    # In order to render HTML and Javascript in a text panel without being sanitized
+    # enable the `disable_sanitize_html` settings in Grafana ini file
+    grafana.ini:
+      panels:
+        disable_sanitize_html: true
+
     service:
       type: NodePort
       nodePort: 32515


### PR DESCRIPTION
This PR adds a generalised volume dashboard for OpenEBS volumes(jiva/cStor excluding localpv).

## Screenshot for the dashboard:
* OpenEBS volume dashboard
![Screenshot from 2021-05-20 23-57-39](https://user-images.githubusercontent.com/44068648/119030486-9129d380-b9c7-11eb-9aa8-5084d927562b.png)

* OpenEBS / cStor / pool dashboard change- Added one text panel
![Screenshot from 2021-05-21 01-58-47](https://user-images.githubusercontent.com/44068648/119044702-2a60e600-b9d8-11eb-950d-a12819c39cb9.png)
 
Signed-off-by: Abhishek Agarwal <abhishek.agarwal@mayadata.io>