### PR TITLE
Update README and NOTES.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # OpenEBS Monitoring add-on
 
-This repository contains monitoring-related (like Prometheus, grafana, etc,) artifacts like helm charts/ YAMLs. The goal of this repository is to provide an easy to setup monitoring stack for OpenEBS. 
+This repository contains monitoring-related (like Prometheus, grafana, etc,) artifacts like helm charts/ YAMLs. The goal of this repository is to provide an easy to setup monitoring stack for OpenEBS.
 
 This repository will aggregate all the monitoring related artifacts that are currently spread across multiple repositories like:
-* https://github.com/openebs/openebs/tree/master/k8s
-* https://github.com/openebs/charts/tree/gh-pages/grafana-charts
+
+- https://github.com/openebs/openebs/tree/master/k8s
+- https://github.com/openebs/charts/tree/gh-pages/grafana-charts
 
 ## Status
 
@@ -37,13 +38,14 @@ _See [helm install](https://helm.sh/docs/helm/helm_install/) for command documen
 #### Accessing Grafana
 
 ```console
-# Look at the grafana pod and note the node name on which this pod is running
-kubectl get pods -n [NAMESPACE] -o wide | grep grafana
-# Note the public IP of the node on which grafana pod is running
+# Look at the grafana pod and check that the pod is in running state
+kubectl get pods -n [NAMESPACE] | grep -i grafana
+# Note the public IP of any one of the nodes
 kubectl get nodes -o wide
 # Open browser and visit http://<NodeIp>:<NodePort> (where <NodeIp> is the public IP address of your node, and default Grafana <NodePort> is 32515)
 # Default Grafana login credentials- [username: admin, password: admin]
 ```
+
 **NOTE:** If public IP is not available then you can access it via port-forwarding
 
 ```console

--- a/deploy/charts/openebs-monitoring/Chart.yaml
+++ b/deploy/charts/openebs-monitoring/Chart.yaml
@@ -34,7 +34,7 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.9
+version: 0.1.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deploy/charts/openebs-monitoring/templates/NOTES.txt
+++ b/deploy/charts/openebs-monitoring/templates/NOTES.txt
@@ -20,7 +20,7 @@ To access the dashboards, form the Grafana URL and open it in the browser
   NOTE: The above IP should be a public IP
 {{- else if contains "ClusterIP" (index $.Values "kube-prometheus-stack" "grafana" "service" "type") }}
   export PORT= {{ index $.Values "kube-prometheus-stack" "grafana" "service" "port" }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name="grafana",app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "call-nested" (list . "kube-prometheus-stack.grafana" "grafana.name") }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 32515:$PORT
   echo "Visit http://127.0.0.1:32515"
 {{- end }}


### PR DESCRIPTION
This PR makes minor updates in README and NOTES.txt.

In README- changed the instruction for accessing Grafana since we are using NodePort service for grafana hence it is exposed to each and every node in the cluster. Hence changed to instruction requesting to only look for nodes where grafana pod is running.

In NOTES.txt- Changed the hard-coded label for finding Grafana pods installed in the cluster to dynamically finding it's configuration since the label value will change according to the chart name of Grafana.

Signed-off-by: Abhishek Agarwal <abhishek.agarwal@mayadata.io>