### PR TITLE
[fix] Jiva & cStor volume dashboard

### DIFF
--- a/deploy/charts/openebs-monitoring/Chart.yaml
+++ b/deploy/charts/openebs-monitoring/Chart.yaml
@@ -34,7 +34,7 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.15
+version: 0.1.16
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deploy/charts/openebs-monitoring/Chart.yaml
+++ b/deploy/charts/openebs-monitoring/Chart.yaml
@@ -34,7 +34,7 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.16
+version: 0.1.17
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deploy/charts/openebs-monitoring/dashboards/Jiva/jiva-volumes.json
+++ b/deploy/charts/openebs-monitoring/dashboards/Jiva/jiva-volumes.json
@@ -1045,9 +1045,7 @@
   "refresh": "1m",
   "schemaVersion": 27,
   "style": "light",
-  "tags": [
-    "OpenEBS"
-  ],
+  "tags": ["OpenEBS"],
   "templating": {
     "list": [
       {
@@ -1102,7 +1100,7 @@
         "allValue": null,
         "current": {},
         "datasource": "$datasource",
-        "definition": "label_values(openebs_size_of_volume{openebs_jiva_label=\"$openebs_jiva_label\"}, openebs_pv)",
+        "definition": "label_values(openebs_size_of_volume{openebs_jiva_label=\"$openebs_jiva_label\", openebs_cstor_label=\"\"}, openebs_pv)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1112,7 +1110,7 @@
         "name": "openebs_Volume",
         "options": [],
         "query": {
-          "query": "label_values(openebs_size_of_volume{openebs_jiva_label=\"$openebs_jiva_label\"}, openebs_pv)",
+          "query": "label_values(openebs_size_of_volume{openebs_jiva_label=\"$openebs_jiva_label\", openebs_cstor_label=\"\"}, openebs_pv)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -1252,17 +1250,7 @@
       "2h",
       "1d"
     ],
-    "time_options": [
-      "5m",
-      "15m",
-      "1h",
-      "6h",
-      "12h",
-      "24h",
-      "2d",
-      "7d",
-      "30d"
-    ]
+    "time_options": ["5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"]
   },
   "timezone": "",
   "title": "OpenEBS / Jiva / Volume dashboard",


### PR DESCRIPTION
**Issue**: 
JIva volume dashboard were showing data for volumes other than jiva provisoned ones. Similar is the case with cStor volume dashboard.
 
### Why was this happening?
Jiva volume dashboard -> When there were no jiva volumes in the cluster, the dashboard template variable `openebs_jiva_label` had empty string value. And filtering openebs volumes upon empty jiva label gave us a list of all OpenEBS volumes(that were not jiva provisioned volumes i.e cstor volumes because `openebs_size_of_volumes` only exports details about jiva and cstor volumes).

Similar explanation for cstor volume dashboard.

**Fix**:
Instead of only using single variable `openebs_jiva_label` for filtering jiva volumes, we also take care of checking whether it is not a cstor volume by adding an extra condition for cstor label --> `openebs_cstor_labels`= ""(empty). This will filter out only jiva provisoned volumes.

Signed-off-by: Abhishek Agarwal <abhishek.agarwal@mayadata.io>