### PR TITLE
Added alert rules for persistent volume claims

### DIFF
--- a/deploy/charts/openebs-monitoring/Chart.yaml
+++ b/deploy/charts/openebs-monitoring/Chart.yaml
@@ -34,7 +34,7 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.15
+version: 0.1.16
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deploy/charts/openebs-monitoring/Chart.yaml
+++ b/deploy/charts/openebs-monitoring/Chart.yaml
@@ -34,12 +34,12 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.18
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 2.8.0
+appVersion: 2.10.0
 
 dependencies:
   - name: kube-prometheus-stack

--- a/deploy/charts/openebs-monitoring/Chart.yaml
+++ b/deploy/charts/openebs-monitoring/Chart.yaml
@@ -39,7 +39,7 @@ version: 0.2.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 2.10.0
+appVersion: 2.9.0
 
 dependencies:
   - name: kube-prometheus-stack

--- a/deploy/charts/openebs-monitoring/dashboards/cStor/cstor-volumes.json
+++ b/deploy/charts/openebs-monitoring/dashboards/cStor/cstor-volumes.json
@@ -1043,9 +1043,7 @@
   "refresh": "1m",
   "schemaVersion": 27,
   "style": "light",
-  "tags": [
-    "OpenEBS"
-  ],
+  "tags": ["OpenEBS"],
   "templating": {
     "list": [
       {
@@ -1100,7 +1098,7 @@
         "allValue": null,
         "current": {},
         "datasource": "$datasource",
-        "definition": "label_values(openebs_size_of_volume{openebs_cstor_label=~\"$openebs_cstor_label\"}, openebs_pv)",
+        "definition": "label_values(openebs_size_of_volume{openebs_cstor_label=~\"$openebs_cstor_label\",openebs_jiva_volume=\"\"}, openebs_pv)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1110,7 +1108,7 @@
         "name": "openebs_Volume",
         "options": [],
         "query": {
-          "query": "label_values(openebs_size_of_volume{openebs_cstor_label=~\"$openebs_cstor_label\"}, openebs_pv)",
+          "query": "label_values(openebs_size_of_volume{openebs_cstor_label=~\"$openebs_cstor_label\",openebs_jiva_volume=\"\"}, openebs_pv)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -1277,17 +1275,7 @@
       "2h",
       "1d"
     ],
-    "time_options": [
-      "5m",
-      "15m",
-      "1h",
-      "6h",
-      "12h",
-      "24h",
-      "2d",
-      "7d",
-      "30d"
-    ]
+    "time_options": ["5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"]
   },
   "timezone": "",
   "title": "OpenEBS / cStor/ Volume dashboard",

--- a/deploy/charts/openebs-monitoring/rules/volumes/pvc-rules.yaml
+++ b/deploy/charts/openebs-monitoring/rules/volumes/pvc-rules.yaml
@@ -1,0 +1,36 @@
+groups:
+  - name: persistent-volume-claim
+    rules:
+      # Alert for pvc's(stale/dangling) that have no owner or not consumed by any pod.
+      - alert: StalePersistentVolumeClaim
+        annotations:
+          summary: 'Persistent Volume Claim ''{{ $labels.persistentvolumeclaim }}'' in namespace ''{{ $labels.namespace }}'' is not consumed by any pod in any namespace'
+          description: |-
+            Persistent Volume Claim '{{ $labels.persistentvolumeclaim }}' has no consumer
+        expr: |-
+          kube_persistentvolumeclaim_info unless (kube_persistentvolumeclaim_info * on(persistentvolumeclaim) group_left kube_pod_spec_volumes_persistentvolumeclaims_info) == 1
+        for: 5m
+        labels:
+          severity: "info"
+      # Alert for pvc's that are in pending state for >5 minutes.
+      - alert: PendingPersistentVolumeClaim
+        annotations:
+          summary: 'Persistent Volume Claim ''{{ $labels.persistentvolumeclaim }}'' pending in namespace ''{{ $labels.namespace }}'''
+          description: |-
+            Persistent Volume Claim '{{ $labels.persistentvolumeclaim }}' has been in pending state for more than 5 minutes
+        expr: |-
+          kube_persistentvolumeclaim_status_phase{phase="Pending"} == 1
+        for: 5m
+        labels:
+          severity: "warning"
+      # Alert for pvc's that are in lost state for >5 minutes.
+      - alert: LostPersistentVolumeClaim
+        annotations:
+          summary: "Persistent Volume Claim '{{ $labels.persistentvolumeclaim }}' in namespace '{{ $labels.namespace }}' lost it's corresponding persistent volume"
+          description: |-
+            Persistent Volume Claim '{{ $labels.persistentvolumeclaim }}' has been in lost state for more than 5 minutes
+        expr: |-
+          kube_persistentvolumeclaim_status_phase{phase="Lost"} == 1
+        for: 5m
+        labels:
+          severity: "warning"

--- a/deploy/charts/openebs-monitoring/values.yaml
+++ b/deploy/charts/openebs-monitoring/values.yaml
@@ -165,6 +165,8 @@ alertRules:
     enabled: true
   Jiva:
     enabled: true
+  volumes:
+    enabled: true
 
 customDashboards:
   cStor:


### PR DESCRIPTION
This PR adds alerts rules for pvc's. Three different types of alerts are added for pvc:
1. Stale/dangling pvc(which are not consumed by any pod)
2. pvc that are in pending state
3. pvc that have lost their corresponding volumes

Signed-off-by: Abhishek Agarwal <abhishek.agarwal@mayadata.io>