### PR TITLE
Fixed dashboard loading error for grafana versions less than 7.4.0

### DIFF
--- a/deploy/charts/openebs-monitoring/Chart.yaml
+++ b/deploy/charts/openebs-monitoring/Chart.yaml
@@ -34,7 +34,7 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deploy/charts/openebs-monitoring/dashboards/Jiva/jiva-volume.json
+++ b/deploy/charts/openebs-monitoring/dashboards/Jiva/jiva-volume.json
@@ -1082,10 +1082,7 @@
         "multi": false,
         "name": "openebs_jiva_label",
         "options": [],
-        "query": {
-          "query": "label_values(openebs_size_of_volume,openebs_jiva_label)",
-          "refId": "StandardVariableQuery"
-        },
+        "query": "label_values(openebs_size_of_volume,openebs_jiva_label)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -1109,10 +1106,7 @@
         "multi": false,
         "name": "openebs_Volume",
         "options": [],
-        "query": {
-          "query": "label_values(openebs_size_of_volume{openebs_jiva_label=\"$openebs_jiva_label\", openebs_cstor_label=\"\"}, openebs_pv)",
-          "refId": "StandardVariableQuery"
-        },
+        "query": "label_values(openebs_size_of_volume{openebs_jiva_label=\"$openebs_jiva_label\", openebs_cstor_label=\"\"}, openebs_pv)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -1136,10 +1130,7 @@
         "multi": false,
         "name": "openebs_pvc",
         "options": [],
-        "query": {
-          "query": "label_values(openebs_size_of_volume{openebs_pv=~\"$openebs_Volume\"},openebs_pvc)",
-          "refId": "Prometheus-openebs_pvc-Variable-Query"
-        },
+        "query": "label_values(openebs_size_of_volume{openebs_pv=~\"$openebs_Volume\"},openebs_pvc)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -1163,10 +1154,7 @@
         "multi": false,
         "name": "replica_count",
         "options": [],
-        "query": {
-          "query": "query_result(openebs_total_replica_count{openebs_pv=~\"$openebs_Volume\"})",
-          "refId": "Prometheus-replica_count-Variable-Query"
-        },
+        "query": "query_result(openebs_total_replica_count{openebs_pv=~\"$openebs_Volume\"})",
         "refresh": 2,
         "regex": "/.*}(.*) .*/",
         "skipUrlSync": false,
@@ -1190,10 +1178,7 @@
         "multi": false,
         "name": "uptime",
         "options": [],
-        "query": {
-          "query": "query_result(openebs_volume_uptime{openebs_pv=~\"$openebs_Volume\"})",
-          "refId": "Prometheus-uptime-Variable-Query"
-        },
+        "query": "query_result(openebs_volume_uptime{openebs_pv=~\"$openebs_Volume\"})",
         "refresh": 2,
         "regex": "/.*}(.*) .*/",
         "skipUrlSync": false,
@@ -1217,10 +1202,7 @@
         "multi": false,
         "name": "vol",
         "options": [],
-        "query": {
-          "query": "label_values(openebs_size_of_volume{openebs_pvc=~\"$openebs_pvc\"},openebs_pv)",
-          "refId": "StandardVariableQuery"
-        },
+        "query": "label_values(openebs_size_of_volume{openebs_pvc=~\"$openebs_pvc\"},openebs_pv)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,

--- a/deploy/charts/openebs-monitoring/dashboards/cStor/cStor-overview.json
+++ b/deploy/charts/openebs-monitoring/dashboards/cStor/cStor-overview.json
@@ -819,10 +819,7 @@
         "multi": false,
         "name": "openebs_cstor_label",
         "options": [],
-        "query": {
-          "query": "label_values(openebs_size_of_volume,openebs_cstor_label)",
-          "refId": "Prometheus-openebs_cstor_label-Variable-Query"
-        },
+        "query": "label_values(openebs_size_of_volume,openebs_cstor_label)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -846,10 +843,7 @@
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": {
-          "query": "query_result(sum(container_memory_working_set_bytes{namespace!=\"\"}) by (namespace))",
-          "refId": "StandardVariableQuery"
-        },
+        "query": "query_result(sum(container_memory_working_set_bytes{namespace!=\"\"}) by (namespace))",
         "refresh": 1,
         "regex": "/namespace=\\\"(.*?)(\\\")/",
         "skipUrlSync": false,

--- a/deploy/charts/openebs-monitoring/dashboards/cStor/cStor-volume.json
+++ b/deploy/charts/openebs-monitoring/dashboards/cStor/cStor-volume.json
@@ -1080,10 +1080,7 @@
         "multi": false,
         "name": "openebs_cstor_label",
         "options": [],
-        "query": {
-          "query": "label_values(openebs_size_of_volume,openebs_cstor_label)",
-          "refId": "Prometheus-openebs_cstor_label-Variable-Query"
-        },
+        "query": "label_values(openebs_size_of_volume,openebs_cstor_label)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -1107,10 +1104,7 @@
         "multi": false,
         "name": "openebs_Volume",
         "options": [],
-        "query": {
-          "query": "label_values(openebs_size_of_volume{openebs_cstor_label=~\"$openebs_cstor_label\",openebs_jiva_label=\"\"}, openebs_pv)",
-          "refId": "StandardVariableQuery"
-        },
+        "query": "label_values(openebs_size_of_volume{openebs_cstor_label=~\"$openebs_cstor_label\",openebs_jiva_label=\"\"}, openebs_pv)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -1134,10 +1128,7 @@
         "multi": false,
         "name": "openebs_pvc",
         "options": [],
-        "query": {
-          "query": "label_values(openebs_size_of_volume{openebs_pv=~\"$openebs_Volume\"},openebs_pvc)",
-          "refId": "Prometheus-openebs_pvc-Variable-Query"
-        },
+        "query": "label_values(openebs_size_of_volume{openebs_pv=~\"$openebs_Volume\"},openebs_pvc)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -1161,10 +1152,7 @@
         "multi": false,
         "name": "pool",
         "options": [],
-        "query": {
-          "query": "label_values(openebs_replica_status{vol=~\"$openebs_Volume\"},cstor_pool)",
-          "refId": "Prometheus-pool-Variable-Query"
-        },
+        "query": "label_values(openebs_replica_status{vol=~\"$openebs_Volume\"},cstor_pool)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -1188,10 +1176,7 @@
         "multi": false,
         "name": "replica_count",
         "options": [],
-        "query": {
-          "query": "query_result(openebs_total_replica_count{openebs_pv=~\"$openebs_Volume\"})",
-          "refId": "Prometheus-replica_count-Variable-Query"
-        },
+        "query": "query_result(openebs_total_replica_count{openebs_pv=~\"$openebs_Volume\"})",
         "refresh": 2,
         "regex": "/.*}(.*) .*/",
         "skipUrlSync": false,
@@ -1215,10 +1200,7 @@
         "multi": false,
         "name": "uptime",
         "options": [],
-        "query": {
-          "query": "query_result(openebs_volume_uptime{openebs_pv=~\"$openebs_Volume\"})",
-          "refId": "Prometheus-uptime-Variable-Query"
-        },
+        "query": "query_result(openebs_volume_uptime{openebs_pv=~\"$openebs_Volume\"})",
         "refresh": 2,
         "regex": "/.*}(.*) .*/",
         "skipUrlSync": false,
@@ -1242,10 +1224,7 @@
         "multi": false,
         "name": "vol",
         "options": [],
-        "query": {
-          "query": "label_values(openebs_size_of_volume{openebs_pvc=~\"$openebs_pvc\"},openebs_pv)",
-          "refId": "Prometheus-vol-Variable-Query"
-        },
+        "query": "label_values(openebs_size_of_volume{openebs_pvc=~\"$openebs_pvc\"},openebs_pv)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,


### PR DESCRIPTION
Signed-off-by: Sahil Raja <sahilraja242@gmail.com>

### What this PR does?

- We were getting error while loading dashboards json in grafana versions lower than 7.4.0
   -  **Error**: `Template variables could not be initialized: e.replace is not a function`

### Reason for this error:

-  This was due to the nested query used over here.
```
"query": {
          "query": "label_values(openebs_size_of_volume,openebs_jiva_label)",
          "refId": "StandardVariableQuery"
        },
```

- So instead of using a nested query, we can simply use an expression in a query.
```
"query": "label_values(openebs_size_of_volume{openebs_jiva_label=\"$openebs_jiva_label\", openebs_cstor_label=\"\"}, openebs_pv)"
```