### PR TITLE
Added npd alert-rules

### DIFF
--- a/deploy/charts/openebs-monitoring/Chart.yaml
+++ b/deploy/charts/openebs-monitoring/Chart.yaml
@@ -34,7 +34,7 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.4
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deploy/charts/openebs-monitoring/rules/volumes/volume-node-rules.yaml
+++ b/deploy/charts/openebs-monitoring/rules/volumes/volume-node-rules.yaml
@@ -1,10 +1,10 @@
 groups:
   - name: volume-node
     rules:
-      # Alert for pv's fileystem getting into read-only state while re-mounting on a particular node.
+      # Alert for pv's fileystem getting into read-only state.
       - alert: VolumeNodeFileSystemIsReadOnly
         annotations:
-          summary: 'Persistent Volume on node ''{{ $labels.node }}'' for persistent volume claim ''{{ $labels.persistentvolumeclaim }}'' is having read-only filesystem while re-mounting'
+          summary: 'Volume mount failed for persistent volume claim ''{{ $labels.persistentvolumeclaim }}'' on node ''{{ $labels.node }}'' due to read-only file-system'
           description: |-
             Persistent Volume's filesystem on node '{{ $labels.node }}' for persistent volume claim '{{ $labels.persistentvolumeclaim }}' has become read-only
         expr: |-
@@ -12,10 +12,10 @@ groups:
         for: 5m
         labels:
           severity: "critical"
-      # Alert for pv's facing issues with ext4 filesystem on a particular nodes.
+      # Alert for pv's facing issues with ext4 filesystem on a particular node.
       - alert: VolumeNodeExt4Error
         annotations:
-          summary: 'Persistent Volume on node ''{{ $labels.node }}'' for persistent volume claim ''{{ $labels.persistentvolumeclaim }}'' is having issues with ext4 filesystem'
+          summary: 'Node ''{{ $labels.node }}'' has encountered errors on ext4 file-system on volume having claim ''{{ $labels.persistentvolumeclaim }}'''
           description: |-
             Persistent Volume's on node '{{ $labels.node }}' persistent volume claim '{{ $labels.persistentvolumeclaim }}' encountering ext4 filesystem error
         expr: |-
@@ -26,7 +26,7 @@ groups:
       # Alert for pv's facing issues with I/O on a particular node.
       - alert: VolumeNodeIOError
         annotations:
-          summary: 'Persistent Volume on node ''{{ $labels.node }}'' for persistent volume claim ''{{ $labels.persistentvolumeclaim }}'' is having trouble with I/O'
+          summary: 'IO errors encountered on volume having persistent volume claim ''{{ $labels.persistentvolumeclaim }}'' on node ''{{ $labels.node }}'''
           description: |-
             Persistent Volume on node '{{ $labels.node }}' for persistent volume claim '{{ $labels.persistentvolumeclaim }}' encountering errors w.r.t buffer I/O 
         expr: |-
@@ -37,7 +37,7 @@ groups:
       # Alert for pv's having some warning issued w.r.t ext4 filesystem.
       - alert: VolumeNodeExt4Warning
         annotations:
-          summary: 'Persistent Volume on node ''{{ $labels.node }}'' for persistent volume claim ''{{ $labels.persistentvolumeclaim }}'' receiving ext4 filesystem warning'
+          summary: 'Node ''{{ $labels.node }}'' has encountered warning on ext4 file-system on volume having claim ''{{ $labels.persistentvolumeclaim }}'''
           description: |-
             Persistent Volume on node '{{ $labels.node }}' receiving ext4 filesystem warning for persistent volume claim '{{ $labels.persistentvolumeclaim }}'
         expr: |-

--- a/deploy/charts/openebs-monitoring/rules/volumes/volume-node-rules.yaml
+++ b/deploy/charts/openebs-monitoring/rules/volumes/volume-node-rules.yaml
@@ -1,10 +1,10 @@
 groups:
   - name: volume-node
     rules:
-      # Alert for pv's fileystem getiing into read-only state while remounting on a particular node.
+      # Alert for pv's fileystem getting into read-only state while re-mounting on a particular node.
       - alert: VolumeNodeFileSystemIsReadOnly
         annotations:
-          summary: 'Persistent Volume on node ''{{ $labels.node }}'' for persistent volume claim ''{{ $labels.persistentvolumeclaim }}'' is having read-only fielsystem while remounting'
+          summary: 'Persistent Volume on node ''{{ $labels.node }}'' for persistent volume claim ''{{ $labels.persistentvolumeclaim }}'' is having read-only filesystem while re-mounting'
           description: |-
             Persistent Volume's filesystem on node '{{ $labels.node }}' for persistent volume claim '{{ $labels.persistentvolumeclaim }}' has become read-only
         expr: |-
@@ -15,7 +15,7 @@ groups:
       # Alert for pv's facing issues with ext4 filesystem on a particular nodes.
       - alert: VolumeNodeExt4Error
         annotations:
-          summary: 'Persistent Volume on node ''{{ $labels.node }}'' for persistent volume claim ''{{ $labels.persistentvolumeclaim }}'' is having issues with ext4 fielsystem'
+          summary: 'Persistent Volume on node ''{{ $labels.node }}'' for persistent volume claim ''{{ $labels.persistentvolumeclaim }}'' is having issues with ext4 filesystem'
           description: |-
             Persistent Volume's on node '{{ $labels.node }}' persistent volume claim '{{ $labels.persistentvolumeclaim }}' encountering ext4 filesystem error
         expr: |-

--- a/deploy/charts/openebs-monitoring/rules/volumes/volume-node-rules.yaml
+++ b/deploy/charts/openebs-monitoring/rules/volumes/volume-node-rules.yaml
@@ -1,0 +1,47 @@
+groups:
+  - name: volume-node
+    rules:
+      # Alert for pv's fileystem getiing into read-only state while remounting on a particular node.
+      - alert: VolumeNodeFileSystemIsReadOnly
+        annotations:
+          summary: 'Persistent Volume on node ''{{ $labels.node }}'' for persistent volume claim ''{{ $labels.persistentvolumeclaim }}'' is having read-only fielsystem while remounting'
+          description: |-
+            Persistent Volume's filesystem on node '{{ $labels.node }}' for persistent volume claim '{{ $labels.persistentvolumeclaim }}' has become read-only
+        expr: |-
+          kubelet_volume_stats_inodes * on(node) group_left(reason) problem_counter{reason="FilesystemIsReadOnly"} > 0
+        for: 5m
+        labels:
+          severity: "critical"
+      # Alert for pv's facing issues with ext4 filesystem on a particular nodes.
+      - alert: VolumeNodeExt4Error
+        annotations:
+          summary: 'Persistent Volume on node ''{{ $labels.node }}'' for persistent volume claim ''{{ $labels.persistentvolumeclaim }}'' is having issues with ext4 fielsystem'
+          description: |-
+            Persistent Volume's on node '{{ $labels.node }}' persistent volume claim '{{ $labels.persistentvolumeclaim }}' encountering ext4 filesystem error
+        expr: |-
+          kubelet_volume_stats_inodes * on(node) group_left(reason) problem_counter{reason="Ext4Error"} > 0
+        for: 5m
+        labels:
+          severity: "critical"
+      # Alert for pv's facing issues with I/O on a particular node.
+      - alert: VolumeNodeIOError
+        annotations:
+          summary: 'Persistent Volume on node ''{{ $labels.node }}'' for persistent volume claim ''{{ $labels.persistentvolumeclaim }}'' is having trouble with I/O'
+          description: |-
+            Persistent Volume on node '{{ $labels.node }}' for persistent volume claim '{{ $labels.persistentvolumeclaim }}' encountering errors w.r.t buffer I/O 
+        expr: |-
+          kubelet_volume_stats_inodes * on(node) group_left(reason) problem_counter{reason="IOError"} > 0
+        for: 5m
+        labels:
+          severity: "critical"
+      # Alert for pv's having some warning issued w.r.t ext4 filesystem.
+      - alert: VolumeNodeExt4Warning
+        annotations:
+          summary: 'Persistent Volume on node ''{{ $labels.node }}'' for persistent volume claim ''{{ $labels.persistentvolumeclaim }}'' receiving ext4 filesystem warning'
+          description: |-
+            Persistent Volume on node '{{ $labels.node }}' receiving ext4 filesystem warning for persistent volume claim '{{ $labels.persistentvolumeclaim }}'
+        expr: |-
+          kubelet_volume_stats_inodes * on(node) group_left(reason) problem_counter{reason="Ext4Warning"} > 0
+        for: 5m
+        labels:
+          severity: "critical"


### PR DESCRIPTION
This PR adds alert-rules for volumes encountering issues on nodes on which it is mounted. The alert-rules include 4 different types of errors:
1. VolumeNodeFileSystemIsReadOnly
2. VolumeNodeExt4Error
3. VolumeNodeIOError
4. VolumeNodeExt4Warning

Signed-off-by: Abhishek Agarwal <abhishek.agarwal@mayadata.io>