### PR TITLE
[fix] Changed the cStor relabelling criteria to remove ; in the pool names

### DIFF
--- a/deploy/charts/openebs-monitoring/Chart.yaml
+++ b/deploy/charts/openebs-monitoring/Chart.yaml
@@ -34,7 +34,7 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deploy/charts/openebs-monitoring/values.yaml
+++ b/deploy/charts/openebs-monitoring/values.yaml
@@ -475,7 +475,7 @@ podMonitors:
             ]
           action: replace
           ## separator: Separator placed between concatenated source label values, default -> ;
-          separator: ""
+          separator: " "
           targetLabel: storage_pool_claim
           ## Adding comma-separated source_labels below in order to fetch the metrics for pool instances of CSP and CSPI kind
         - sourceLabels:
@@ -485,7 +485,7 @@ podMonitors:
             ]
           action: replace
           ## separator: Separator placed between concatenated source label values, default -> ;
-          separator: ""
+          separator: " "
           targetLabel: cstor_pool
         - sourceLabels:
             [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]


### PR DESCRIPTION
This PR fixes the following case: 
**Display name for pool name and pool cluster is prefixed with `;`**

The separator used was empty string but that somehow is not getting applied. Therefore for now changed the separator from empty string to " "(blank space) just so the UI gets improved for the users. Blank space looks better than a ';'.