### PR TITLE
fix(dashboard): Fix localPV workload dashboard for GKE clusters

### DIFF
--- a/.github/workflows/release-charts.yml
+++ b/.github/workflows/release-charts.yml
@@ -36,4 +36,4 @@ jobs:
         env:
           CR_TOKEN: "${{ secrets.CR_TOKEN }}"
         with:
-          charts_dir: deploy/charts
+          charts_dir: deploy

--- a/deploy/charts/Chart.yaml
+++ b/deploy/charts/Chart.yaml
@@ -34,7 +34,7 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.3
+version: 0.4.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deploy/charts/dashboards/localPV/localpv-workload.json
+++ b/deploy/charts/dashboards/localPV/localpv-workload.json
@@ -1842,7 +1842,7 @@
                "targets": [
                   {
                      "exemplar": true,
-                     "expr": "node_filesystem_size_bytes {fstype=~\"ext4|xfs\",mountpoint=~\"(.+/($pvName/mount))\"}",
+                     "expr": "node_filesystem_size_bytes {fstype=~\"ext4|xfs\",mountpoint=~\"(^/var/lib/.+/($pvName/mount))\"}",
                      "instant": true,
                      "interval": "",
                      "intervalFactor": 2,
@@ -1934,7 +1934,7 @@
                "targets": [
                   {
                      "exemplar": true,
-                     "expr": "100 - ((node_filesystem_avail_bytes{mountpoint=~\"(.+/($pvName/mount))\",fstype=~\"ext4|xfs\"} * 100) / node_filesystem_size_bytes {mountpoint=~\"(.+/($pvName/mount))\",fstype=~\"ext4|xfs\"})",
+                     "expr": "100 - ((node_filesystem_avail_bytes{mountpoint=~\"(^/var/lib/.+/($pvName/mount))\",fstype=~\"ext4|xfs\"} * 100) / node_filesystem_size_bytes {mountpoint=~\"(^/var/lib/.+/($pvName/mount))\",fstype=~\"ext4|xfs\"})",
                      "interval": "10s",
                      "intervalFactor": 2,
                      "legendFormat": "",
@@ -2007,7 +2007,7 @@
                "targets": [
                   {
                      "exemplar": true,
-                     "expr": "100 - ((node_filesystem_avail_bytes{mountpoint=~\"(.+/($pvName/mount))\"} * 100) / node_filesystem_size_bytes {mountpoint=~\"(.+/($pvName/mount))\"})",
+                     "expr": "100 - ((node_filesystem_avail_bytes{mountpoint=~\"(^/var/lib/.+/($pvName/mount))\"} * 100) / node_filesystem_size_bytes {mountpoint=~\"(^/var/lib/.+/($pvName/mount))\"})",
                      "interval": "10s",
                      "intervalFactor": 2,
                      "legendFormat": "Pvc: $pvcName, Mount Point: {{mountpoint}}",
@@ -2110,7 +2110,7 @@
                "targets": [
                   {
                      "exemplar": true,
-                     "expr": "node_filesystem_avail_bytes{mountpoint=~\"(.+/($pvName/mount))\"}",
+                     "expr": "node_filesystem_avail_bytes{mountpoint=~\"(^/var/lib/.+/($pvName/mount))\"}",
                      "format": "time_series",
                      "hide": false,
                      "interval": "",
@@ -2216,7 +2216,7 @@
                "targets": [
                   {
                      "exemplar": true,
-                     "expr": "node_filesystem_files_free{mountpoint=~\"(.+/($pvName/mount))\"}",
+                     "expr": "node_filesystem_files_free{mountpoint=~\"(^/var/lib/.+/($pvName/mount))\"}",
                      "format": "time_series",
                      "hide": false,
                      "interval": "",
@@ -2321,7 +2321,7 @@
                "targets": [
                   {
                      "exemplar": true,
-                     "expr": "node_filesystem_files{mountpoint=~\"(.+/($pvName/mount))\"}",
+                     "expr": "node_filesystem_files{mountpoint=~\"(^/var/lib/.+/($pvName/mount))\"}",
                      "format": "time_series",
                      "hide": false,
                      "interval": "",
@@ -2431,7 +2431,7 @@
                "targets": [
                   {
                      "exemplar": true,
-                     "expr": "node_filesystem_readonly{mountpoint=~\"(.+/($pvName/mount))\"}",
+                     "expr": "node_filesystem_readonly{mountpoint=~\"(^/var/lib/.+/($pvName/mount))\"}",
                      "format": "time_series",
                      "interval": "",
                      "intervalFactor": 2,
@@ -2541,7 +2541,7 @@
                "targets": [
                   {
                      "exemplar": true,
-                     "expr": "node_filesystem_device_error{mountpoint=~\"(.+/($pvName/mount))\"} ",
+                     "expr": "node_filesystem_device_error{mountpoint=~\"(^/var/lib/.+/($pvName/mount))\"} ",
                      "format": "time_series",
                      "hide": false,
                      "interval": "",
@@ -2676,7 +2676,7 @@
                "targets": [
                   {
                      "exemplar": true,
-                     "expr": "100 - ((node_filesystem_avail_bytes{mountpoint=~\"(.+/($pvName/mount))\"} * 100) / node_filesystem_size_bytes{mountpoint=~\"(.+/($pvName/mount))\"})",
+                     "expr": "100 - ((node_filesystem_avail_bytes{mountpoint=~\"(^/var/lib/.+/($pvName/mount))\"} * 100) / node_filesystem_size_bytes{mountpoint=~\"(^/var/lib/.+/($pvName/mount))\"})",
                      "format": "time_series",
                      "interval": "",
                      "intervalFactor": 2,

--- a/jsonnet/openebs-mixin/build.sh
+++ b/jsonnet/openebs-mixin/build.sh
@@ -6,8 +6,8 @@ set -x
 # only exit with zero if all commands of the pipeline exit successfully
 set -o pipefail
 
-dashboardsDirPath=../../deploy/charts/openebs-monitoring/dashboards
-rulesDirPath=../../deploy/charts/openebs-monitoring/rules
+dashboardsDirPath=../../deploy/charts/dashboards
+rulesDirPath=../../deploy/charts/rules
 
 generateDashboards(){
 	rm -rf $dashboardsDirPath

--- a/jsonnet/openebs-mixin/dashboards/openebs/localpv-workload.json
+++ b/jsonnet/openebs-mixin/dashboards/openebs/localpv-workload.json
@@ -1838,7 +1838,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "node_filesystem_size_bytes {fstype=~\"ext4|xfs\",mountpoint=~\"(.+/($pvName/mount))\"}",
+              "expr": "node_filesystem_size_bytes {fstype=~\"ext4|xfs\",mountpoint=~\"(^/var/lib/.+/($pvName/mount))\"}",
               "instant": true,
               "interval": "",
               "intervalFactor": 2,
@@ -1926,7 +1926,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "100 - ((node_filesystem_avail_bytes{mountpoint=~\"(.+/($pvName/mount))\",fstype=~\"ext4|xfs\"} * 100) / node_filesystem_size_bytes {mountpoint=~\"(.+/($pvName/mount))\",fstype=~\"ext4|xfs\"})",
+              "expr": "100 - ((node_filesystem_avail_bytes{mountpoint=~\"(^/var/lib/.+/($pvName/mount))\",fstype=~\"ext4|xfs\"} * 100) / node_filesystem_size_bytes {mountpoint=~\"(^/var/lib/.+/($pvName/mount))\",fstype=~\"ext4|xfs\"})",
               "interval": "10s",
               "intervalFactor": 2,
               "legendFormat": "",
@@ -1999,7 +1999,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "100 - ((node_filesystem_avail_bytes{mountpoint=~\"(.+/($pvName/mount))\"} * 100) / node_filesystem_size_bytes {mountpoint=~\"(.+/($pvName/mount))\"})",
+              "expr": "100 - ((node_filesystem_avail_bytes{mountpoint=~\"(^/var/lib/.+/($pvName/mount))\"} * 100) / node_filesystem_size_bytes {mountpoint=~\"(^/var/lib/.+/($pvName/mount))\"})",
               "interval": "10s",
               "intervalFactor": 2,
               "legendFormat": "Pvc: $pvcName, Mount Point: {{mountpoint}}",
@@ -2102,7 +2102,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "node_filesystem_avail_bytes{mountpoint=~\"(.+/($pvName/mount))\"}",
+              "expr": "node_filesystem_avail_bytes{mountpoint=~\"(^/var/lib/.+/($pvName/mount))\"}",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -2208,7 +2208,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "node_filesystem_files_free{mountpoint=~\"(.+/($pvName/mount))\"}",
+              "expr": "node_filesystem_files_free{mountpoint=~\"(^/var/lib/.+/($pvName/mount))\"}",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -2313,7 +2313,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "node_filesystem_files{mountpoint=~\"(.+/($pvName/mount))\"}",
+              "expr": "node_filesystem_files{mountpoint=~\"(^/var/lib/.+/($pvName/mount))\"}",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -2423,7 +2423,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "node_filesystem_readonly{mountpoint=~\"(.+/($pvName/mount))\"}",
+              "expr": "node_filesystem_readonly{mountpoint=~\"(^/var/lib/.+/($pvName/mount))\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -2533,7 +2533,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "node_filesystem_device_error{mountpoint=~\"(.+/($pvName/mount))\"} ",
+              "expr": "node_filesystem_device_error{mountpoint=~\"(^/var/lib/.+/($pvName/mount))\"} ",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -2668,7 +2668,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "100 - ((node_filesystem_avail_bytes{mountpoint=~\"(.+/($pvName/mount))\"} * 100) / node_filesystem_size_bytes{mountpoint=~\"(.+/($pvName/mount))\"})",
+              "expr": "100 - ((node_filesystem_avail_bytes{mountpoint=~\"(^/var/lib/.+/($pvName/mount))\"} * 100) / node_filesystem_size_bytes{mountpoint=~\"(^/var/lib/.+/($pvName/mount))\"})",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,


### PR DESCRIPTION
### Cluster:
- GKE 

### Issue:
![image (2)](https://user-images.githubusercontent.com/32039199/132033861-aadbf482-4af6-4212-a200-fb39e82aee66.png)

- This issue was due to two different mount points. GKE has an experimental mounter path set as
  ```
  --experimental-mounter-path=/home/kubernetes/containerized_mounter/
  ```

### Fix:

- Used regex expr to match mount point starting with `/var/lib`.