### PR TITLE
Update kube-prometheus-stack version

### DIFF
--- a/deploy/charts/Chart.lock
+++ b/deploy/charts/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: kube-prometheus-stack
   repository: https://prometheus-community.github.io/helm-charts
-  version: 16.5.0
+  version: 18.0.5
 - name: node-problem-detector
   repository: https://charts.deliveryhero.io/
-  version: 2.0.5
-digest: sha256:dbd415d49e75b981ec7319effc051d7fc9a299b6317bedc3001f3179128ed6db
-generated: "2021-08-30T12:27:03.54243733+05:30"
+  version: 2.0.7
+digest: sha256:fdb98f59b1db59c4299f74b59c0b2fc167d856c58118e3ae5d6f2a6f5e2b66c0
+generated: "2021-09-07T22:01:54.050548449+05:30"

--- a/deploy/charts/Chart.yaml
+++ b/deploy/charts/Chart.yaml
@@ -34,7 +34,7 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.5
+version: 0.4.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deploy/charts/Chart.yaml
+++ b/deploy/charts/Chart.yaml
@@ -43,7 +43,7 @@ appVersion: 2.12.0
 
 dependencies:
   - name: kube-prometheus-stack
-    version: "16.5.*"
+    version: "18.0.*"
     repository: https://prometheus-community.github.io/helm-charts
     condition: kube-prometheus-stack.install
   - name: node-problem-detector


### PR DESCRIPTION
Signed-off-by: Sahil Raja <sahilraja242@gmail.com>

- Updated kube-prometheus-stack version.(16.5.* -> 18.0.*)

#### Issue
- `job.batch/openebs-monitoring-kube-pr-admission-patch` was not getting completed in kube-prometheus-stack version 16.5.* .