### PR TITLE
Workload Dashboard: Change tag "openEBS" to "OpenEBS"

### DIFF
--- a/jsonnet/openebs-mixin/dashboards/openebs/localpv-workload.json
+++ b/jsonnet/openebs-mixin/dashboards/openebs/localpv-workload.json
@@ -3951,7 +3951,7 @@
   "refresh": "10s",
   "schemaVersion": 27,
   "style": "dark",
-  "tags": ["openEBS", "Local PV"],
+  "tags": ["OpenEBS", "Local PV"],
   "templating": {
     "list": [
       {


### PR DESCRIPTION
closes #75 

In the Stateful Workload Dashboard, changed the tag from "openEBS" to "OpenEBS" for uniformity