### PR TITLE
add port-forward when NodePort is used

### DIFF
--- a/deploy/charts/templates/NOTES.txt
+++ b/deploy/charts/templates/NOTES.txt
@@ -19,6 +19,12 @@ To access the dashboards, form the Grafana URL and open it in the browser
   export NODE_IP=$(kubectl get node $NODE_NAME -o jsonpath='{$.status.addresses[?(@.type=="ExternalIP")].address}')
   echo http://$NODE_IP:$NODE_PORT
   NOTE: The above IP should be a public IP
+  echo
+Or you could use a port-forward to forward to 8080
+  export SVC_NAME=$(kubectl -n {{ .Release.Namespace }} get svc -l "app.kubernetes.io/name={{ include "call-nested" (list . "kube-prometheus-stack.grafana" "grafana.name") }},app.kubernetes.io/instance={{ .Release.Name }}" -o name)
+  kubectl --namespace {{ .Release.Namespace }} port-forward $SVC_NAME 8080:80
+  echo "Visit http://127.0.0.1:8080"
+
 {{- else if contains "ClusterIP" (index $.Values "kube-prometheus-stack" "grafana" "service" "type") }}
   export PORT= {{ index $.Values "kube-prometheus-stack" "grafana" "service" "port" }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "call-nested" (list . "kube-prometheus-stack.grafana" "grafana.name") }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")


### PR DESCRIPTION
when the externalIP is not available, we could use the port-forward instead.