### PR TITLE
Make Makefile more robust

### DIFF
--- a/jsonnet/Makefile
+++ b/jsonnet/Makefile
@@ -1,4 +1,4 @@
-SHELL=/bin/bash -o pipefail
+SHELL=/usr/bin/env bash -o pipefail
 
 BIN_DIR?=$(shell pwd)/tmp/bin
 


### PR DESCRIPTION
posix does not require bash to be available at /bin/bash, and some OS like NixOS do not have it there. ```/usr/bin/env bash``` is the recommended way to solve this issue and should have no negative side effects.