### PR TITLE
chore(chart): check CRDs available before installing prometheus resources

### DIFF
--- a/deploy/charts/templates/podmonitors.yaml
+++ b/deploy/charts/templates/podmonitors.yaml
@@ -1,3 +1,4 @@
+{{ if (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
 {{- range $monitoringAddon, $fields := .Values.openebsMonitoringAddon }}
 {{- if (and (hasKey $fields "enabled") ($fields.enabled)) }}
 {{- if (hasKey $fields "podMonitor") }}
@@ -23,6 +24,7 @@ spec:
 {{ toYaml $fields.podMonitor.podMetricsEndpoints.relabelings | indent 8 }}
 {{- end }}
 ---
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/deploy/charts/templates/prometheusRules.yaml
+++ b/deploy/charts/templates/prometheusRules.yaml
@@ -1,3 +1,4 @@
+{{ if (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
 {{- $alertRules := dict -}}
 {{- range $monitoringAddon,$fields := .Values.openebsMonitoringAddon }}
 {{- if (and (hasKey $fields "enabled") ($fields.enabled)) }}
@@ -25,6 +26,7 @@ metadata:
 spec:
 {{ $.Files.Get $fileName | indent 2 }}
 ---
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/deploy/charts/templates/servicemonitors.yaml
+++ b/deploy/charts/templates/servicemonitors.yaml
@@ -1,3 +1,4 @@
+{{ if (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
 {{- range $monitoringAddon, $fields := .Values.openebsMonitoringAddon }}
 {{- if (and (hasKey $fields "enabled") ($fields.enabled)) }}
 {{- if (hasKey $fields "serviceMonitor") }}
@@ -23,6 +24,7 @@ spec:
 {{ toYaml $fields.serviceMonitor.endpoints.relabelings | indent 8 }}
 {{- end }}
 ---
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Prometheus  resources should not be rendered unless Prometheus CRDs are available.

This changeset includes an extra option to override the `apiVersion` Prometheus provides.

close https://github.com/openebs/monitoring/issues/107