### PR TITLE
chore: update to allow node exporter port change

### DIFF
--- a/deploy/charts/values.yaml
+++ b/deploy/charts/values.yaml
@@ -29,6 +29,8 @@ kube-prometheus-stack:
   prometheus-node-exporter:
     rbac:
       pspEnabled: false
+    service:
+      port:
 
     ## privilege and access control settings for node-exporter
     securityContext:


### PR DESCRIPTION
Update so that the port used by the prometheus
nod exporter can be configured at install time.