### PR TITLE
Fix: add namespace to PVC rules to avoid many-to-many joins

### DIFF
--- a/deploy/charts/rules/volume/volume-rules.json
+++ b/deploy/charts/rules/volume/volume-rules.json
@@ -9,7 +9,7 @@
                   "description": "Persistent Volume Claim '{{ $labels.persistentvolumeclaim }}' has no consumer",
                   "summary": "Persistent Volume Claim '{{ $labels.persistentvolumeclaim }}' in namespace '{{ $labels.namespace }}' is not consumed by any pod in any namespace"
                },
-               "expr": "kube_persistentvolumeclaim_info unless (kube_persistentvolumeclaim_info * on(persistentvolumeclaim) group_left (max by (persistentvolumeclaim) (kube_pod_spec_volumes_persistentvolumeclaims_info)))) == 1",
+               "expr": "kube_persistentvolumeclaim_info UNLESS ON (namespace, persistentvolumeclaim) count by (namespace, persistentvolumeclaim) (kube_pod_spec_volumes_persistentvolumeclaims_info) == 1",
                "for": "5m",
                "labels": {
                   "severity": "info"

--- a/jsonnet/openebs-mixin/rules/volume/volume-rules.libsonnet
+++ b/jsonnet/openebs-mixin/rules/volume/volume-rules.libsonnet
@@ -14,7 +14,7 @@ function(param) {
                 summary: "Persistent Volume Claim '{{ $labels.persistentvolumeclaim }}' in namespace '{{ $labels.namespace }}' is not consumed by any pod in any namespace",
                 description: "Persistent Volume Claim '{{ $labels.persistentvolumeclaim }}' has no consumer",
               },
-              expr: 'kube_persistentvolumeclaim_info unless (kube_persistentvolumeclaim_info * on(persistentvolumeclaim) group_left kube_pod_spec_volumes_persistentvolumeclaims_info) == 1',
+              expr: 'kube_persistentvolumeclaim_info UNLESS ON (namespace, persistentvolumeclaim) count by (namespace, persistentvolumeclaim) (kube_pod_spec_volumes_persistentvolumeclaims_info) == 1',
               'for': '5m',
               labels: {
                 severity: 'info',


### PR DESCRIPTION
This pull request updates the Prometheus alerting rules for detecting unconsumed Persistent Volume Claims (PVCs) to improve accuracy and maintain consistency across configurations.

This ensures that PVC's with the same labels in different namespaces will not cause duplication errors.

### Changes to Prometheus alerting rules:

* Updated the `expr` field in `deploy/charts/rules/volume/volume-rules.json` to use `UNLESS ON (namespace, persistentvolumeclaim)` with `count by (namespace, persistentvolumeclaim)` for better alignment with Prometheus query language best practices.
* Made a similar update to the `expr` field in `jsonnet/openebs-mixin/rules/volume/volume-rules.libsonnet` to ensure consistency with the JSON configuration.