### PR TITLE
Fix mayastor_diskpool variable in the diskpool dashboard

### DIFF
--- a/deploy/charts/dashboards/mayastor/mayastor-diskpool.json
+++ b/deploy/charts/dashboards/mayastor/mayastor-diskpool.json
@@ -802,7 +802,7 @@
             },
             "datasource": {
                "type": "prometheus",
-               "uid": "prometheus"
+               "uid": "${datasource}"
             },
             "definition": "label_values(diskpool_status,name)",
             "hide": 0,


### PR DESCRIPTION
The mayastor diskpool dashboard has a broken datasource - it searches for the "prometheus" datasource instead of the datasource configured during import (and/or selected from the datasource variable)